### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy Worker
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/zachthedev/ddns/security/code-scanning/3](https://github.com/zachthedev/ddns/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly limit the `GITHUB_TOKEN` permissions. Since the workflow does not appear to require write access to the repository, we will set `contents: read` as the minimal permission. This ensures that the workflow adheres to the principle of least privilege while maintaining its functionality.

The changes will be made at the root level of the workflow file, `.github/workflows/deploy.yml`, by adding the `permissions` block immediately after the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
