### PR TITLE
feat!: DNS-scoped token auth, per-record IP cache, explicit ip4/ip6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ the Cloudflare Workers pool, ESLint + prettier, lefthook hooks.
 - Deploy (local or CI): `bun run deploy` (see scripts/deploy.ts)
 - First-time setup on a clone or fork: `bun run setup`
 
+Cloudflare resource naming: `<type>-<project>-<purpose>-<env>`, e.g.
+`kv-uddns-cache-prod`, `kv-uddns-cache-dev`, `d1-uddns-audit-prod`. Binding
+names in code stay short (`DDNS_KV`). Workers themselves: `<project>-<env>`.
+
 Rules:
 
 @.claude/rules/github-cli.md

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This worker exists for what the native client doesn't do:
 - **Push notifications** via [ntfy](https://ntfy.sh) when your IP actually changes
 - **Multi-hostname updates** in a single entry (comma-separated), including across multiple zones
 - **Record preservation**: proxy status, TTL, and comments on existing records survive updates
-- **`ip=auto`** for routers behind NAT that would otherwise report a private IP
+- **`ip4=auto` / `ip6=auto`** for routers behind NAT that would otherwise report a private IP
 - **Audit history** of DNS changes for compliance
 
 ## 🚀 **Setup Overview**
@@ -95,8 +95,8 @@ injected at deploy time from the environment.
    - **Hostname:** `subdomain.example.com` or `example.com`
    - **Username:** Any value (the field is ignored; the API token does the authenticating)
    - **Password:** Cloudflare User API Token scoped to DNS edit _(not an Account API Token)_
-   - **Server:** `<worker-name>.<worker-subdomain>.workers.dev/update?ip=%i&hostname=%h`
-     _(Omit `https://`. To update several records at once, use a comma-separated list: `hostnames=example.com,*.example.com`. Optional parameters: `ip6=<address>` updates AAAA records alongside, `zone=example.com` restricts matching to one zone.)_
+   - **Server:** `<worker-name>.<worker-subdomain>.workers.dev/update?ip4=%i&ip6=auto&hostnames=%h`
+     _(Omit `https://`. Comma-separate to update several records at once: `hostnames=example.com,*.example.com`. `ip4`/`ip6` each accept a literal address or `auto`, which uses the connecting IP when it matches that family and skips the slot otherwise; provide at least one. Optional `zone=example.com` restricts matching to one zone.)_
 
 ## 🛠️ **Testing & Troubleshooting**
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ A Cloudflare Worker script that enables UniFi devices (e.g., UDM-Pro, USG) to dy
 
 This is a fork from [willswire](https://github.com/willswire/unifi-ddns) with the following enhancements:
 
-- **Smart notifications** - Only sends [ntfy](https://ntfy.sh) alerts when your IP actually changes
+- **Smart notifications** - Only sends [ntfy](https://ntfy.sh) alerts when a DNS record actually changes
 - **API** - Returns structured JSON responses instead of plain text
 - **Multi-hostname support** - Update multiple hostnames in a single request using comma-separated values
-- **Multi-zone support** - API tokens can manage DNS records across multiple zones
+- **Multi-zone support** - API tokens can manage DNS records across multiple zones, with optional `zone=` scoping
+- **Dual-stack support** - Update A and AAAA records together with the `ip6` parameter
+- **Token-only auth** - DNS-scoped API tokens; no account email anywhere
 
 ## Why Use This?
 
@@ -91,10 +93,10 @@ injected at deploy time from the environment.
 3. Create New Dynamic DNS with the following information:
    - **Service:** `custom`
    - **Hostname:** `subdomain.example.com` or `example.com`
-   - **Username:** Cloudflare Account Email Address (e.g., `you@example.com`)
-   - **Password:** Cloudflare User API Token _(not an Account API Token)_
+   - **Username:** Any value (the field is ignored; the API token does the authenticating)
+   - **Password:** Cloudflare User API Token scoped to DNS edit _(not an Account API Token)_
    - **Server:** `<worker-name>.<worker-subdomain>.workers.dev/update?ip=%i&hostname=%h`
-     _(Omit `https://`. To update several records at once, use a comma-separated list: `hostnames=example.com,*.example.com`)_
+     _(Omit `https://`. To update several records at once, use a comma-separated list: `hostnames=example.com,*.example.com`. Optional parameters: `ip6=<address>` updates AAAA records alongside, `zone=example.com` restricts matching to one zone.)_
 
 ## 🛠️ **Testing & Troubleshooting**
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,8 +25,8 @@ This distinction is crucial to ensure the DDNS updates function correctly.
 2. **Create New Dynamic DNS Entry:**
    - **Service:** Select `custom`.
    - **Hostname:** Enter your desired hostname (e.g., `subdomain.example.com`).
-   - **Username:** Enter your Cloudflare account email.
-   - **Password:** Enter your Cloudflare API token.
+   - **Username:** Any value; the field is ignored.
+   - **Password:** Enter your DNS-scoped Cloudflare API token.
    - **Server:** Enter the appropriate server address based on your device model (see FAQ #1).
 
 3. **Save Configuration:**

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -11,9 +11,10 @@ The server configuration depends on your UniFi device model:
   - **Note:** Do **not** include the path with variables.
 
 - **Newer Gateways (e.g., UDM series, UXG series):**
-  - **Server:** `<worker-name>.<worker-subdomain>.workers.dev/update?ip=%i&hostname=%h`
+  - **Server:** `<worker-name>.<worker-subdomain>.workers.dev/update?ip4=%i&ip6=auto&hostnames=%h`
   - **Note:** Include the full path with variables. Multiple hostnames are
     supported as a comma-separated list, e.g. `hostnames=example.com,*.example.com`.
+    Drop `ip6=auto` if you have no IPv6.
 
 This distinction is crucial to ensure the DDNS updates function correctly.
 
@@ -106,9 +107,9 @@ Assign separate DDNS providers to each WAN interface if supported. Using the `cu
 
 ## 11. How can I use Unifi devices behind NAT?
 
-In case the Unifi router is deployed behind a NAT gateway (e.g. cable modem in router mode, 5G modem or similar), it will likely get a non-routable RFC 1918 address assigned on the external interface. In this case, the Unifi router would incorrectly update DNS to the non-routable external IP address via `ip=%i`.
+In case the Unifi router is deployed behind a NAT gateway (e.g. cable modem in router mode, 5G modem or similar), it will likely get a non-routable RFC 1918 address assigned on the external interface. In this case, the Unifi router would incorrectly update DNS to the non-routable external IP address via `ip4=%i`.
 
-To support scenarios where such a router needs to be externally available (e.g. via port forwarding on the NAT gateway), you can use `ip=auto` instead of `ip=%i` to have the Cloudflare worker automatically determine the Unifi router's NATed IP address and use it for correctly updating the hostname's `A` record.
+To support scenarios where such a router needs to be externally available (e.g. via port forwarding on the NAT gateway), you can use `ip4=auto` instead of `ip4=%i` to have the Cloudflare worker automatically determine the Unifi router's NATed IP address and use it for correctly updating the hostname's `A` record. The same applies to `ip6=auto` for AAAA records.
 
 ## 12. What should I do if I continue to experience issues with DDNS updates?
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,28 +115,69 @@ function constructClientOptions(request: Request): ClientOptions {
 	return { apiToken: token };
 }
 
-function constructDNSRecords(request: Request): UpdateRequest {
-	const { searchParams } = new URL(request.url);
-	let ip = (searchParams.get('ip') ?? searchParams.get('myip'))?.trim() ?? null;
-	const ip6 = searchParams.get('ip6')?.trim() ?? null;
-	const hostnameParam = (searchParams.get('hostnames') ?? searchParams.get('hostname'))?.trim() ?? null;
-	const zoneFilter = searchParams.get('zone')?.trim() ?? null;
+interface ResolvedIps {
+	v4: string | null;
+	v6: string | null;
+}
 
-	if (ip === null || ip === '') {
-		throw new HttpError(422, "Missing 'ip' parameter. Use ip=auto to use the client IP.");
-	} else if (ip === 'auto') {
-		ip = request.headers.get('CF-Connecting-IP');
-		if (ip === null || ip === '') {
-			throw new HttpError(500, 'ip=auto specified but client IP could not be determined.');
+/**
+ * Resolves the requested IPs from the ip4/ip6 parameters.
+ *
+ * Literals are validated against their address family. `auto` takes the
+ * connecting IP only when it matches the slot's family and silently skips
+ * the slot otherwise: dual-stack callers (UniFi may dial over either
+ * family) can request both without flapping.
+ */
+function resolveIps(searchParams: URLSearchParams, request: Request): ResolvedIps {
+	const raw4 = searchParams.get('ip4')?.trim() ?? null;
+	const raw6 = searchParams.get('ip6')?.trim() ?? null;
+	const connectingIp = request.headers.get('CF-Connecting-IP');
+
+	let v4: string | null = null;
+	if (raw4 !== null && raw4 !== '') {
+		if (raw4 === 'auto') {
+			if (connectingIp?.includes('.')) {
+				v4 = connectingIp;
+			} else {
+				console.log('ip4=auto requested but the client did not connect over IPv4; skipping A records.');
+			}
+		} else if (!raw4.includes('.')) {
+			throw new HttpError(422, "The 'ip4' parameter must be a valid IPv4 address.");
+		} else {
+			v4 = raw4;
 		}
 	}
 
-	if (ip6 !== null && ip6 !== '' && !ip6.includes(':')) {
-		throw new HttpError(422, "The 'ip6' parameter must be a valid IPv6 address.");
+	let v6: string | null = null;
+	if (raw6 !== null && raw6 !== '') {
+		if (raw6 === 'auto') {
+			if (connectingIp?.includes(':')) {
+				v6 = connectingIp;
+			} else {
+				console.log('ip6=auto requested but the client did not connect over IPv6; skipping AAAA records.');
+			}
+		} else if (!raw6.includes(':')) {
+			throw new HttpError(422, "The 'ip6' parameter must be a valid IPv6 address.");
+		} else {
+			v6 = raw6;
+		}
 	}
 
+	if (v4 === null && v6 === null) {
+		throw new HttpError(422, "Missing IP. Provide 'ip4' and/or 'ip6'; 'auto' uses the client IP.");
+	}
+
+	return { v4, v6 };
+}
+
+function constructDNSRecords(request: Request): UpdateRequest {
+	const { searchParams } = new URL(request.url);
+	const { v4, v6 } = resolveIps(searchParams, request);
+	const hostnameParam = searchParams.get('hostnames')?.trim() ?? null;
+	const zoneFilter = searchParams.get('zone')?.trim() ?? null;
+
 	if (hostnameParam === null || hostnameParam === '') {
-		throw new HttpError(422, "Missing 'hostname' parameter.");
+		throw new HttpError(422, "Missing 'hostnames' parameter.");
 	}
 	const hostnames = hostnameParam
 		.split(',')
@@ -146,23 +187,14 @@ function constructDNSRecords(request: Request): UpdateRequest {
 		throw new HttpError(422, 'No hostnames provided.');
 	}
 
-	// One record per hostname, plus an AAAA per hostname for dual-stack
-	// callers that supply ip6 alongside an IPv4 ip.
+	// Per hostname: an A record when ip4 resolved, an AAAA when ip6 did.
 	const records: DDNSRecord[] = [];
 	for (const hostname of hostnames) {
-		records.push({
-			content: ip,
-			name: hostname,
-			type: ip.includes('.') ? 'A' : 'AAAA',
-			ttl: 1,
-		});
-		if (ip6 !== null && ip6 !== '') {
-			records.push({
-				content: ip6,
-				name: hostname,
-				type: 'AAAA',
-				ttl: 1,
-			});
+		if (v4 !== null) {
+			records.push({ content: v4, name: hostname, type: 'A', ttl: 1 });
+		}
+		if (v6 !== null) {
+			records.push({ content: v6, name: hostname, type: 'AAAA', ttl: 1 });
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,37 @@
 import { Cloudflare, type ClientOptions } from 'cloudflare';
-import type { AAAARecord, ARecord } from 'cloudflare/resources/dns/records';
 import { pushNtfy } from './pushNtfy';
 
-type AddressableRecord = ARecord | AAAARecord;
+/**
+ * A DNS record this worker manages. Narrower than the SDK's record types:
+ * every field is required because the worker constructs them itself.
+ */
+interface DDNSRecord {
+	content: string;
+	name: string;
+	type: 'A' | 'AAAA';
+	ttl: number;
+}
+
+interface UpdateRequest {
+	records: DDNSRecord[];
+	/** Optional explicit zone scoping via the `zone` query parameter. */
+	zoneFilter: string | null;
+}
+
+// KV is a pure cache; DNS itself is the source of truth for the last IP.
+// Entries expire so stale identities can never accumulate (issue #151), at
+// the cost of one redundant API round-trip per record per TTL window.
+const KV_KEY_PREFIX = 'ip';
+const KV_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+interface CachedIp {
+	ip: string;
+	updatedAt: string;
+}
+
+function cacheKey(record: DDNSRecord): string {
+	return `${KV_KEY_PREFIX}:${record.name}:${record.type}`;
+}
 
 export class HttpError extends Error {
 	constructor(
@@ -15,14 +44,19 @@ export class HttpError extends Error {
 	}
 }
 
+interface RecordResult {
+	hostname: string;
+	type: string;
+	ip: string;
+	updated: boolean;
+}
+
 interface UpdateResponseBody {
 	success: boolean;
 	message: string;
 	data: {
-		ip: string;
-		previousIp?: string | null;
 		updated: boolean;
-		records?: { hostname: string | undefined; type: string | undefined }[];
+		records: RecordResult[];
 	};
 }
 
@@ -33,39 +67,60 @@ function jsonResponse(body: UpdateResponseBody | { success: false; error: string
 	});
 }
 
+/**
+ * Extracts the Cloudflare API token from the Authorization header.
+ *
+ * Two forms are accepted:
+ * - `Basic base64(username:token)`: what UniFi devices send. The username is
+ *   ignored; only the DNS-scoped API token matters.
+ * - `Bearer token`: the raw token, for direct callers.
+ */
 function constructClientOptions(request: Request): ClientOptions {
 	const authHeader = request.headers.get('Authorization');
 	if (authHeader === null || authHeader === '') {
 		throw new HttpError(401, 'Authorization required.');
 	}
 
-	const [, token] = authHeader.split(' ');
-	if (token === undefined || token === '') {
+	const [scheme, payload] = authHeader.split(' ');
+	if (payload === undefined || payload === '') {
+		throw new HttpError(401, 'Invalid authorization credentials.');
+	}
+
+	if (scheme === 'Bearer') {
+		return { apiToken: payload };
+	}
+
+	if (scheme !== 'Basic') {
 		throw new HttpError(401, 'Invalid authorization credentials.');
 	}
 
 	let decoded: string;
 	try {
-		decoded = atob(token);
+		decoded = atob(payload);
 	} catch {
 		throw new HttpError(401, 'Invalid authorization credentials.');
 	}
+
 	const delimiterIndex = decoded.indexOf(':');
 	// eslint-disable-next-line no-control-regex
 	if (delimiterIndex === -1 || /[\0-\x1F\x7F]/.test(decoded)) {
 		throw new HttpError(401, 'Invalid authorization credentials.');
 	}
 
-	return {
-		apiEmail: decoded.slice(0, delimiterIndex),
-		apiToken: decoded.slice(delimiterIndex + 1),
-	};
+	const token = decoded.slice(delimiterIndex + 1);
+	if (token === '') {
+		throw new HttpError(401, 'Invalid authorization credentials.');
+	}
+
+	return { apiToken: token };
 }
 
-function constructDNSRecord(request: Request): AddressableRecord[] {
+function constructDNSRecords(request: Request): UpdateRequest {
 	const { searchParams } = new URL(request.url);
 	let ip = (searchParams.get('ip') ?? searchParams.get('myip'))?.trim() ?? null;
+	const ip6 = searchParams.get('ip6')?.trim() ?? null;
 	const hostnameParam = (searchParams.get('hostnames') ?? searchParams.get('hostname'))?.trim() ?? null;
+	const zoneFilter = searchParams.get('zone')?.trim() ?? null;
 
 	if (ip === null || ip === '') {
 		throw new HttpError(422, "Missing 'ip' parameter. Use ip=auto to use the client IP.");
@@ -74,6 +129,10 @@ function constructDNSRecord(request: Request): AddressableRecord[] {
 		if (ip === null || ip === '') {
 			throw new HttpError(500, 'ip=auto specified but client IP could not be determined.');
 		}
+	}
+
+	if (ip6 !== null && ip6 !== '' && !ip6.includes(':')) {
+		throw new HttpError(422, "The 'ip6' parameter must be a valid IPv6 address.");
 	}
 
 	if (hostnameParam === null || hostnameParam === '') {
@@ -87,16 +146,55 @@ function constructDNSRecord(request: Request): AddressableRecord[] {
 		throw new HttpError(422, 'No hostnames provided.');
 	}
 
-	// For each hostname, create the corresponding DNS record object.
-	return hostnames.map((hostname) => ({
-		content: ip,
-		name: hostname,
-		type: ip.includes('.') ? 'A' : 'AAAA',
-		ttl: 1,
-	}));
+	// One record per hostname, plus an AAAA per hostname for dual-stack
+	// callers that supply ip6 alongside an IPv4 ip.
+	const records: DDNSRecord[] = [];
+	for (const hostname of hostnames) {
+		records.push({
+			content: ip,
+			name: hostname,
+			type: ip.includes('.') ? 'A' : 'AAAA',
+			ttl: 1,
+		});
+		if (ip6 !== null && ip6 !== '') {
+			records.push({
+				content: ip6,
+				name: hostname,
+				type: 'AAAA',
+				ttl: 1,
+			});
+		}
+	}
+
+	return { records, zoneFilter: zoneFilter === '' ? null : zoneFilter };
 }
 
-async function updateHostnames(clientOptions: ClientOptions, newRecords: AddressableRecord[], env: Env): Promise<Response> {
+/** Reads a record's cached IP; any failure or unparseable entry is a miss. */
+async function readCachedIp(env: Env, record: DDNSRecord): Promise<string | null> {
+	try {
+		const raw = await env.DDNS_KV.get(cacheKey(record));
+		if (raw === null) return null;
+		const parsed = JSON.parse(raw) as Partial<CachedIp>;
+		return typeof parsed.ip === 'string' ? parsed.ip : null;
+	} catch (error) {
+		console.error(`Failed to read IP cache for ${cacheKey(record)}:`, error);
+		return null;
+	}
+}
+
+/** Caches a record's IP with a TTL so stale entries clean themselves up. */
+async function writeCachedIp(env: Env, record: DDNSRecord): Promise<void> {
+	const value: CachedIp = { ip: record.content, updatedAt: new Date().toISOString() };
+	try {
+		await env.DDNS_KV.put(cacheKey(record), JSON.stringify(value), { expirationTtl: KV_TTL_SECONDS });
+	} catch (error) {
+		console.error(`Failed to write IP cache for ${cacheKey(record)}:`, error);
+		// The cache is an optimization; the update already succeeded.
+	}
+}
+
+async function updateHostnames(clientOptions: ClientOptions, updateRequest: UpdateRequest, env: Env): Promise<Response> {
+	const { records, zoneFilter } = updateRequest;
 	const cloudflare = new Cloudflare(clientOptions);
 
 	// Verify token status
@@ -105,107 +203,120 @@ async function updateHostnames(clientOptions: ClientOptions, newRecords: Address
 		throw new HttpError(401, `Authentication failed: token ${tokenStatus}`);
 	}
 
-	// Track last known IP per user so unchanged IPs skip the update and
-	// notification entirely.
-	const userEmail = clientOptions.apiEmail ?? 'unknown';
-	const userKey = `ip:${userEmail}`;
-
-	const firstRecord = newRecords[0];
-	const currentIp = firstRecord?.content;
-	if (currentIp === undefined || currentIp === '') {
-		throw new HttpError(500, 'Unexpected error: no records provided');
-	}
-
-	let lastKnownIp: string | null = null;
-	try {
-		lastKnownIp = await env.DDNS_KV.get(userKey);
-	} catch (error) {
-		console.error(`Failed to get last known IP for user ${userEmail} from KV:`, error);
-		// Continue with the update if KV access fails
-	}
-
-	if (lastKnownIp === currentIp) {
-		console.log(`IP address ${currentIp} hasn't changed for user ${userEmail}. Skipping DNS update and notification.`);
+	// Fast path: when every record's cached IP already matches, skip the
+	// zone and record API calls entirely.
+	const cachedIps = await Promise.all(records.map(async (record) => readCachedIp(env, record)));
+	const pending = records.filter((record, i) => cachedIps[i] !== record.content);
+	if (pending.length === 0) {
+		console.log('All records match their cached IPs. Skipping DNS update and notification.');
 		return jsonResponse(
 			{
 				success: true,
 				message: 'No IP change detected',
-				data: { ip: currentIp, updated: false },
+				data: {
+					updated: false,
+					records: records.map((r) => ({ hostname: r.name, type: r.type, ip: r.content, updated: false })),
+				},
 			},
 			200,
 		);
 	}
 
-	const { result: zones } = await cloudflare.zones.list();
+	let { result: zones } = await cloudflare.zones.list();
+	if (zoneFilter !== null) {
+		zones = zones.filter((zone) => zone.name === zoneFilter);
+		if (zones.length === 0) {
+			throw new HttpError(400, `Zone '${zoneFilter}' not available with current permissions.`);
+		}
+	}
 	if (zones.length === 0) {
 		throw new HttpError(400, 'No zones available with current permissions.');
 	}
 
 	const updateMessages: string[] = [];
+	const results: RecordResult[] = [];
 
-	for (const newRecord of newRecords) {
-		// Retrieve the matching DNS record across all visible zones
-		const matches: { record: AddressableRecord & { id: string }; zoneId: string }[] = [];
+	for (const record of records) {
+		if (!pending.includes(record)) {
+			results.push({ hostname: record.name, type: record.type, ip: record.content, updated: false });
+			continue;
+		}
+
+		// Retrieve the matching DNS record across the visible zones
+		const matches: {
+			id: string;
+			content: string | undefined;
+			proxied: boolean;
+			comment: string | undefined;
+			ttl: number;
+			zoneId: string;
+		}[] = [];
 		for (const zone of zones) {
-			const { result: records } = await cloudflare.dns.records.list({
+			const { result: existing } = await cloudflare.dns.records.list({
 				zone_id: zone.id,
-				name: newRecord.name as Cloudflare.DNS.Records.RecordListParams.Name,
-				type: newRecord.type,
+				name: record.name as Cloudflare.DNS.Records.RecordListParams.Name,
+				type: record.type,
 			});
 			matches.push(
-				...records.filter((rec) => rec.id).map((rec) => ({ record: rec as AddressableRecord & { id: string }, zoneId: zone.id })),
+				...existing
+					.filter((rec) => rec.id)
+					.map((rec) => ({
+						id: rec.id,
+						content: rec.content,
+						// The SDK types mark proxied/ttl required, but the live API
+						// can omit them; default at the boundary.
+						proxied: rec.proxied ?? false,
+						comment: rec.comment,
+						ttl: rec.ttl ?? 1,
+						zoneId: zone.id,
+					})),
 			);
 		}
 
 		const match = matches[0];
 		if (match === undefined) {
-			throw new HttpError(400, `No matching record found for '${newRecord.name ?? ''}'. Create it manually first.`);
+			throw new HttpError(400, `No matching record found for '${record.name}'. Create it manually first.`);
 		}
 		if (matches.length > 1) {
-			throw new HttpError(400, `Multiple matching records found for '${newRecord.name ?? ''}'. Specify a unique hostname per zone.`);
+			throw new HttpError(400, `Multiple matching records found for '${record.name}'. Specify a unique hostname per zone.`);
 		}
 
-		const { record, zoneId } = match;
-		// The SDK types mark proxied/ttl required, but the live API can omit
-		// them; default at the boundary instead of trusting the declaration.
-		const { comment } = record;
-		const proxied = record.proxied ?? false;
-		const ttl = record.ttl ?? 1;
-		await cloudflare.dns.records.update(record.id, {
-			content: newRecord.content,
-			zone_id: zoneId,
-			name: newRecord.name,
-			type: newRecord.type,
-			proxied,
-			comment,
-			ttl,
-		});
+		// Notifications key off the actual DNS delta, never the cache: a
+		// cache miss on an unchanged record refreshes silently.
+		const changed = match.content !== record.content;
+		if (changed) {
+			await cloudflare.dns.records.update(match.id, {
+				content: record.content,
+				zone_id: match.zoneId,
+				name: record.name,
+				type: record.type,
+				proxied: match.proxied,
+				comment: match.comment,
+				ttl: match.ttl,
+			});
 
-		const successMsg = `DNS record for '${newRecord.name ?? ''}' ('${newRecord.type ?? ''}') updated to '${newRecord.content ?? ''}'`;
-		console.log(successMsg);
-		updateMessages.push(successMsg);
+			const successMsg = `DNS record for '${record.name}' ('${record.type}') updated to '${record.content}'`;
+			console.log(successMsg);
+			updateMessages.push(successMsg);
+		} else {
+			console.log(`DNS record for '${record.name}' ('${record.type}') already at '${record.content}'. Refreshing cache only.`);
+		}
+
+		await writeCachedIp(env, record);
+		results.push({ hostname: record.name, type: record.type, ip: record.content, updated: changed });
 	}
 
-	// Store the new IP address as the last known IP for this user
-	try {
-		await env.DDNS_KV.put(userKey, currentIp);
-	} catch (error) {
-		console.error(`Failed to store last known IP for user ${userEmail} to KV:`, error);
-		// Continue even if KV storage fails
-	}
-
-	// Send one grouped notification for all updates
+	// Send one grouped notification for the records that actually changed
 	await pushNtfy(updateMessages, env);
 
+	const anyUpdated = updateMessages.length > 0;
 	return jsonResponse(
 		{
 			success: true,
-			message: 'DNS records updated successfully',
+			message: anyUpdated ? 'DNS records updated successfully' : 'DNS records already current',
 			data: {
-				ip: currentIp,
-				previousIp: lastKnownIp,
-				updated: true,
-				records: newRecords.map((r) => ({ hostname: r.name, type: r.type })),
+				updated: anyUpdated,
+				records: results,
 			},
 		},
 		200,
@@ -224,8 +335,8 @@ export default {
 
 		try {
 			const clientOptions = constructClientOptions(request);
-			const record = constructDNSRecord(request);
-			return await updateHostnames(clientOptions, record, env);
+			const updateRequest = constructDNSRecords(request);
+			return await updateHostnames(clientOptions, updateRequest, env);
 		} catch (err: unknown) {
 			const isHttpError = err instanceof HttpError;
 			const message = isHttpError ? err.message : 'Internal Server Error';

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -26,7 +26,7 @@ export const createMockKVNamespace = (): KVNamespace => {
 
 	return {
 		get: vi.fn((key: string) => Promise.resolve(storage.get(key) ?? null)),
-		put: vi.fn((key: string, value: string) => {
+		put: vi.fn((key: string, value: string, _options?: { expirationTtl?: number }) => {
 			storage.set(key, value);
 			return Promise.resolve(undefined);
 		}),
@@ -69,9 +69,14 @@ export const createMockRequest = (
 	});
 };
 
-export const createAuthHeader = (email: string, token: string): string => {
-	const credentials = btoa(`${email}:${token}`);
-	return `Bearer ${credentials}`;
+/** Emits a Basic auth header: `Basic base64(user:token)`. */
+export const createAuthHeader = (user: string, token: string): string => {
+	return `Basic ${btoa(`${user}:${token}`)}`;
+};
+
+/** Emits a Bearer auth header: `Bearer <rawToken>`. */
+export const createBearerHeader = (rawToken: string): string => {
+	return `Bearer ${rawToken}`;
 };
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import worker, { HttpError } from '../src/index';
-import { createMockCloudflareClient, createMockEnv, createMockRequest, createAuthHeader, wireStandardHappyPath } from './helpers/mocks';
+import {
+	createMockCloudflareClient,
+	createMockEnv,
+	createMockRequest,
+	createAuthHeader,
+	createBearerHeader,
+	wireStandardHappyPath,
+} from './helpers/mocks';
 import { Cloudflare } from 'cloudflare';
 
 // Mock the Cloudflare SDK
@@ -60,7 +67,7 @@ describe('Worker fetch handler', () => {
 	// -------------------------------------------------------------------------
 
 	describe('Auth parsing', () => {
-		it('accepts valid authorization credentials', async () => {
+		it('accepts Basic credentials and constructs SDK with apiToken only (no apiEmail)', async () => {
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
@@ -71,12 +78,41 @@ describe('Worker fetch handler', () => {
 			const response = await worker.fetch(request, env);
 
 			// Fails with 'No zones available' but confirms auth passed and Cloudflare
-			// was initialised with the decoded credentials.
+			// was initialised with apiToken only (username portion is discarded).
 			expect(response.status).toBe(400);
 			expect(vi.mocked(Cloudflare)).toHaveBeenCalledWith({
-				apiEmail: 'user@example.com',
 				apiToken: 'valid-token',
 			});
+			// apiEmail must never be passed
+			expect(vi.mocked(Cloudflare)).not.toHaveBeenCalledWith(expect.objectContaining({ apiEmail: expect.anything() }));
+		});
+
+		it('accepts Basic credentials with a non-email username (username is ignored)', async () => {
+			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
+			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: { Authorization: createAuthHeader('somedevice', 'mytoken') },
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(400);
+			expect(vi.mocked(Cloudflare)).toHaveBeenCalledWith({ apiToken: 'mytoken' });
+		});
+
+		it('accepts Bearer raw-token and constructs SDK with that token directly', async () => {
+			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
+			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: { Authorization: createBearerHeader('raw-api-token') },
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(400);
+			expect(vi.mocked(Cloudflare)).toHaveBeenCalledWith({ apiToken: 'raw-api-token' });
 		});
 
 		it('rejects request without Authorization header', async () => {
@@ -92,19 +128,40 @@ describe('Worker fetch handler', () => {
 			});
 		});
 
-		it('rejects request with invalid Authorization format', async () => {
+		it('rejects request with empty Authorization header', async () => {
 			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
-				headers: { Authorization: 'InvalidFormat' },
+				headers: { Authorization: '' },
 			});
 
 			const response = await worker.fetch(request, env);
 
 			expect(response.status).toBe(401);
 			const body = (await response.json()) as any;
-			expect(body).toEqual({
-				success: false,
-				error: 'Invalid authorization credentials.',
+			expect(body).toEqual({ success: false, error: 'Authorization required.' });
+		});
+
+		it('rejects request with unknown scheme', async () => {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: { Authorization: 'Digest abc123' },
 			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(401);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({ success: false, error: 'Invalid authorization credentials.' });
+		});
+
+		it('rejects request with scheme only (missing payload)', async () => {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: { Authorization: 'Basic' },
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(401);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({ success: false, error: 'Invalid authorization credentials.' });
 		});
 
 		it('rejects request with empty Bearer token', async () => {
@@ -122,25 +179,9 @@ describe('Worker fetch handler', () => {
 			});
 		});
 
-		it('rejects request with invalid base64 encoding', async () => {
+		it('rejects Basic with invalid base64 payload', async () => {
 			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
-				headers: { Authorization: 'Bearer !!invalid!!base64!!' },
-			});
-
-			const response = await worker.fetch(request, env);
-
-			// Malformed base64 is a client error, same as any other bad credential
-			expect(response.status).toBe(401);
-			const body = (await response.json()) as any;
-			expect(body).toEqual({
-				success: false,
-				error: 'Invalid authorization credentials.',
-			});
-		});
-
-		it('rejects request with missing delimiter in credentials', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
-				headers: { Authorization: `Bearer ${btoa('noddelimiter')}` },
+				headers: { Authorization: 'Basic !!invalid!!base64!!' },
 			});
 
 			const response = await worker.fetch(request, env);
@@ -153,9 +194,39 @@ describe('Worker fetch handler', () => {
 			});
 		});
 
-		it('rejects request with control characters in credentials', async () => {
+		it('rejects Basic where decoded value has no colon delimiter', async () => {
 			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
-				headers: { Authorization: `Bearer ${btoa('email@example.com:\x00token')}` },
+				headers: { Authorization: `Basic ${btoa('nodelemiter')}` },
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(401);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: 'Invalid authorization credentials.',
+			});
+		});
+
+		it('rejects Basic where decoded value contains control characters', async () => {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: { Authorization: `Basic ${btoa('user:\x00token')}` },
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(401);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: 'Invalid authorization credentials.',
+			});
+		});
+
+		it('rejects Basic where token after colon is empty', async () => {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: { Authorization: `Basic ${btoa('user:')}` },
 			});
 
 			const response = await worker.fetch(request, env);
@@ -203,7 +274,7 @@ describe('Worker fetch handler', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// DNS record construction  (constructDNSRecord param validation)
+	// DNS record construction  (constructDNSRecords param validation)
 	// -------------------------------------------------------------------------
 
 	describe('DNS record construction', () => {
@@ -250,6 +321,22 @@ describe('Worker fetch handler', () => {
 
 			// Fails with 'No zones available' but confirms parameter was accepted
 			expect(response.status).toBe(400);
+		});
+
+		it('trims whitespace from ip parameter', async () => {
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+			mockCloudflareClient.dns.records.list.mockResolvedValue({ result: [] } as any);
+
+			const request = createMockRequest('https://example.com/update?ip=%20%201.2.3.4%20&hostname=test.example.com', {
+				headers: validAuth,
+			});
+
+			await worker.fetch(request, env);
+
+			// The A-record lookup ran with the trimmed address
+			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledWith(expect.objectContaining({ name: 'test.example.com', type: 'A' }));
 		});
 
 		it('detects IPv4 address and queries for A record', async () => {
@@ -306,6 +393,56 @@ describe('Worker fetch handler', () => {
 			// confirms the comma-separated list was parsed and the first lookup ran.
 			expect(response.status).toBe(400);
 			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledTimes(1);
+		});
+
+		it('adds an AAAA record per hostname when ip6 is provided alongside ip', async () => {
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+
+			// A record for host1, AAAA for host1, A record for host2, AAAA for host2
+			mockCloudflareClient.dns.records.list
+				.mockResolvedValueOnce({
+					result: [{ id: 'r1', name: 'h1.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }],
+				} as any)
+				.mockResolvedValueOnce({
+					result: [{ id: 'r2', name: 'h1.example.com', type: 'AAAA', content: '::1', proxied: false, ttl: 1 }],
+				} as any)
+				.mockResolvedValueOnce({
+					result: [{ id: 'r3', name: 'h2.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }],
+				} as any)
+				.mockResolvedValueOnce({
+					result: [{ id: 'r4', name: 'h2.example.com', type: 'AAAA', content: '::1', proxied: false, ttl: 1 }],
+				} as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&ip6=2001:db8::1&hostname=h1.example.com,h2.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env);
+			const body = (await response.json()) as any;
+
+			expect(response.status).toBe(200);
+			// 2 A records + 2 AAAA records = 4 entries
+			expect(body.data.records).toHaveLength(4);
+			// The four DNS record lookups ran
+			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledTimes(4);
+		});
+
+		it('rejects ip6 value that does not contain a colon', async () => {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&ip6=notanipv6&hostname=test.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(422);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: "The 'ip6' parameter must be a valid IPv6 address.",
+			});
 		});
 
 		it('rejects request without ip parameter', async () => {
@@ -409,21 +546,22 @@ describe('Worker fetch handler', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// KV change detection
+	// KV cache  (read / write / fast-path)
 	// -------------------------------------------------------------------------
 
-	describe('KV change detection', () => {
+	describe('KV cache', () => {
 		const validAuth = { Authorization: createAuthHeader('user@example.com', 'token') };
 
 		beforeEach(() => {
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
 		});
 
-		it('skips update when IP has not changed', async () => {
+		it('skips zone listing and returns 200 when ALL records match their cached IPs', async () => {
 			const kvMock = vi.mocked(env.DDNS_KV) as any;
-			kvMock.get.mockResolvedValue('192.168.1.1');
+			// Cache contains a JSON entry with matching IP
+			kvMock.get.mockResolvedValue(JSON.stringify({ ip: '1.2.3.4', updatedAt: '2024-01-01T00:00:00.000Z' }));
 
-			const request = createMockRequest('https://example.com/update?ip=192.168.1.1&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -435,15 +573,15 @@ describe('Worker fetch handler', () => {
 				success: true,
 				message: 'No IP change detected',
 				data: {
-					ip: '192.168.1.1',
 					updated: false,
+					records: [{ hostname: 'test.example.com', type: 'A', ip: '1.2.3.4', updated: false }],
 				},
 			});
-			// Short-circuits before zone listing
+			// Short-circuits: zones.list must not be called
 			expect(mockCloudflareClient.zones.list).not.toHaveBeenCalled();
 		});
 
-		it('stores new IP after a successful update', async () => {
+		it('uses cache key ip:<hostname>:<type>', async () => {
 			const kvMock = vi.mocked(env.DDNS_KV) as any;
 			kvMock.get.mockResolvedValue(null);
 			kvMock.put.mockResolvedValue(undefined);
@@ -452,30 +590,80 @@ describe('Worker fetch handler', () => {
 				result: [{ id: 'zone1', name: 'example.com' }],
 			} as any);
 			mockCloudflareClient.dns.records.list.mockResolvedValue({
-				result: [
-					{
-						id: 'record1',
-						name: 'test.example.com',
-						type: 'A',
-						content: '192.168.1.1',
-						proxied: false,
-						ttl: 300,
-					},
-				],
+				result: [{ id: 'r1', name: 'test.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }],
 			} as any);
-			mockCloudflareClient.dns.records.update.mockResolvedValue({ success: true } as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=192.168.1.2&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: validAuth,
+			});
+
+			await worker.fetch(request, env);
+
+			expect(kvMock.get).toHaveBeenCalledWith('ip:test.example.com:A');
+			expect(kvMock.put).toHaveBeenCalledWith('ip:test.example.com:A', expect.any(String), { expirationTtl: 2592000 });
+		});
+
+		it('writes JSON {ip, updatedAt} to KV with expirationTtl 2592000', async () => {
+			const kvMock = vi.mocked(env.DDNS_KV) as any;
+			kvMock.get.mockResolvedValue(null);
+			kvMock.put.mockResolvedValue(undefined);
+
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+			mockCloudflareClient.dns.records.list.mockResolvedValue({
+				result: [{ id: 'r1', name: 'test.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }],
+			} as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: validAuth,
+			});
+
+			await worker.fetch(request, env);
+
+			const [, rawValue, putOptions] = kvMock.put.mock.calls[0];
+			const parsed = JSON.parse(rawValue) as { ip: string; updatedAt: string };
+			expect(parsed.ip).toBe('1.2.3.4');
+			expect(typeof parsed.updatedAt).toBe('string');
+			expect(putOptions).toEqual({ expirationTtl: 2592000 });
+		});
+
+		it('treats malformed cached JSON as a cache miss and proceeds', async () => {
+			const kvMock = vi.mocked(env.DDNS_KV) as any;
+			kvMock.get.mockResolvedValue('not-json-at-all');
+
+			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
 				headers: validAuth,
 			});
 
 			const response = await worker.fetch(request, env);
 
-			expect(response.status).toBe(200);
-			expect(kvMock.put).toHaveBeenCalledWith('ip:user@example.com', '192.168.1.2');
+			// Proceeded past the cache miss and reached zone listing
+			expect(mockCloudflareClient.zones.list).toHaveBeenCalled();
+			expect(response.status).toBe(400);
 		});
 
-		it('returns success even when KV put fails', async () => {
+		it('treats a KV read error as a cache miss and proceeds', async () => {
+			const kvMock = vi.mocked(env.DDNS_KV) as any;
+			kvMock.get.mockRejectedValue(new Error('KV read error'));
+
+			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(mockCloudflareClient.zones.list).toHaveBeenCalled();
+			expect(response.status).toBe(400);
+		});
+
+		it('returns 200 and DNS update still succeeds when KV put throws', async () => {
 			const kvMock = vi.mocked(env.DDNS_KV) as any;
 			kvMock.get.mockResolvedValue(null);
 			kvMock.put.mockRejectedValue(new Error('KV write error'));
@@ -484,77 +672,82 @@ describe('Worker fetch handler', () => {
 				result: [{ id: 'zone1', name: 'example.com' }],
 			} as any);
 			mockCloudflareClient.dns.records.list.mockResolvedValue({
-				result: [
-					{
-						id: 'record1',
-						name: 'test.example.com',
-						type: 'A',
-						content: '192.168.1.1',
-						proxied: false,
-						ttl: 300,
-					},
-				],
+				result: [{ id: 'r1', name: 'test.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 300 }],
 			} as any);
-			mockCloudflareClient.dns.records.update.mockResolvedValue({ success: true } as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=192.168.1.2&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
 				headers: validAuth,
 			});
 
 			const response = await worker.fetch(request, env);
 
-			// DNS update was still performed despite the KV failure
 			expect(response.status).toBe(200);
 			expect(mockCloudflareClient.dns.records.update).toHaveBeenCalled();
 		});
 
-		it('proceeds with update when IP has changed', async () => {
+		it('proceeds to update when cached IP differs from requested IP', async () => {
 			const kvMock = vi.mocked(env.DDNS_KV) as any;
-			kvMock.get.mockResolvedValue('192.168.1.1');
+			kvMock.get.mockResolvedValue(JSON.stringify({ ip: '1.2.3.3', updatedAt: '2024-01-01T00:00:00.000Z' }));
 
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=192.168.1.2&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
 				headers: validAuth,
 			});
 
 			await worker.fetch(request, env);
 
-			// Fails with 'No zones available' but confirms it proceeded past the IP check
+			// Proceeded past the cache check
 			expect(mockCloudflareClient.zones.list).toHaveBeenCalled();
 		});
 
-		it('proceeds with update when no previous IP exists', async () => {
+		it('proceeds to update when no cache entry exists', async () => {
 			const kvMock = vi.mocked(env.DDNS_KV) as any;
 			kvMock.get.mockResolvedValue(null);
 
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=192.168.1.1&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
 				headers: validAuth,
 			});
 
 			await worker.fetch(request, env);
 
-			// Fails with 'No zones available' but confirms it proceeded past the IP check
 			expect(mockCloudflareClient.zones.list).toHaveBeenCalled();
 		});
 
-		it('continues past a KV get failure', async () => {
+		it('handles partial cache: cached hostname skipped, pending hostname fetches DNS', async () => {
 			const kvMock = vi.mocked(env.DDNS_KV) as any;
-			kvMock.get.mockRejectedValue(new Error('KV error'));
+			// First hostname cached and matching; second hostname not cached
+			kvMock.get
+				.mockResolvedValueOnce(JSON.stringify({ ip: '1.2.3.4', updatedAt: '2024-01-01T00:00:00.000Z' }))
+				.mockResolvedValueOnce(null);
+			kvMock.put.mockResolvedValue(undefined);
 
-			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+			mockCloudflareClient.dns.records.list.mockResolvedValue({
+				result: [{ id: 'r2', name: 'h2.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }],
+			} as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=192.168.1.1&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=h1.example.com,h2.example.com', {
 				headers: validAuth,
 			});
 
 			const response = await worker.fetch(request, env);
+			const body = (await response.json()) as any;
 
-			// Confirms it continued past the KV read error and reached zone listing
-			expect(mockCloudflareClient.zones.list).toHaveBeenCalled();
-			expect(response.status).toBe(400);
+			expect(response.status).toBe(200);
+			// Both hostnames appear in the result
+			expect(body.data.records).toHaveLength(2);
+			// Only the non-cached hostname triggered a DNS lookup
+			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledTimes(1);
+			// The cached entry appears as updated:false
+			const cachedEntry = (body.data.records as any[]).find((r: any) => r.hostname === 'h1.example.com');
+			expect(cachedEntry).toMatchObject({ hostname: 'h1.example.com', updated: false });
 		});
 	});
 
@@ -591,7 +784,7 @@ describe('Worker fetch handler', () => {
 				],
 			} as any);
 
-			mockCloudflareClient.dns.records.update.mockResolvedValue({ success: true } as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
 			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=sub.test.com', {
 				headers: validAuth,
@@ -602,6 +795,49 @@ describe('Worker fetch handler', () => {
 			expect(response.status).toBe(200);
 			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledTimes(2);
 			expect(mockCloudflareClient.dns.records.update).toHaveBeenCalledWith('record1', expect.objectContaining({ zone_id: 'zone2' }));
+		});
+
+		it('filters zones by name when zone param is provided', async () => {
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [
+					{ id: 'zone1', name: 'example.com' },
+					{ id: 'zone2', name: 'other.com' },
+				],
+			} as any);
+			mockCloudflareClient.dns.records.list.mockResolvedValue({
+				result: [{ id: 'r1', name: 'test.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }],
+			} as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com&zone=example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(200);
+			// Only the matching zone was searched
+			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledTimes(1);
+			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledWith(expect.objectContaining({ zone_id: 'zone1' }));
+		});
+
+		it('returns 400 when zone filter matches no available zones', async () => {
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com&zone=notmine.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(400);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: "Zone 'notmine.com' not available with current permissions.",
+			});
 		});
 
 		it('fails when no zones are available', async () => {
@@ -641,7 +877,7 @@ describe('Worker fetch handler', () => {
 			});
 		});
 
-		it('fails when multiple matching records are found', async () => {
+		it('fails when multiple matching records are found across zones', async () => {
 			mockCloudflareClient.zones.list.mockResolvedValue({
 				result: [
 					{ id: 'zone1', name: 'example.com' },
@@ -684,9 +920,10 @@ describe('Worker fetch handler', () => {
 		beforeEach(() => {
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
 			(vi.mocked(env.DDNS_KV) as any).get.mockResolvedValue(null);
+			(vi.mocked(env.DDNS_KV) as any).put.mockResolvedValue(undefined);
 		});
 
-		it('successfully updates a single DNS record', async () => {
+		it('successfully updates a single DNS record and returns the correct shape', async () => {
 			const { pushNtfy } = await import('../src/pushNtfy');
 			const pushNtfyMock = vi.mocked(pushNtfy);
 
@@ -706,7 +943,7 @@ describe('Worker fetch handler', () => {
 					},
 				],
 			} as any);
-			mockCloudflareClient.dns.records.update.mockResolvedValue({ success: true } as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
 			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=test.example.com', {
 				headers: validAuth,
@@ -720,10 +957,8 @@ describe('Worker fetch handler', () => {
 				success: true,
 				message: 'DNS records updated successfully',
 				data: {
-					ip: '1.2.3.5',
-					previousIp: null,
 					updated: true,
-					records: [{ hostname: 'test.example.com', type: 'A' }],
+					records: [{ hostname: 'test.example.com', type: 'A', ip: '1.2.3.5', updated: true }],
 				},
 			});
 
@@ -740,6 +975,57 @@ describe('Worker fetch handler', () => {
 			expect(pushNtfyMock).toHaveBeenCalledWith(["DNS record for 'test.example.com' ('A') updated to '1.2.3.5'"], env);
 		});
 
+		it('does not call dns.records.update when existing content already matches target IP (DNS-delta no-op)', async () => {
+			const { pushNtfy } = await import('../src/pushNtfy');
+			const pushNtfyMock = vi.mocked(pushNtfy);
+
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+			// Existing DNS content already matches the requested IP
+			mockCloudflareClient.dns.records.list.mockResolvedValue({
+				result: [{ id: 'r1', name: 'test.example.com', type: 'A', content: '1.2.3.4', proxied: false, ttl: 1 }],
+			} as any);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env);
+			const body = (await response.json()) as any;
+
+			expect(response.status).toBe(200);
+			expect(body.message).toBe('DNS records already current');
+			expect(body.data.updated).toBe(false);
+			expect(body.data.records[0]).toMatchObject({ hostname: 'test.example.com', ip: '1.2.3.4', updated: false });
+			// Update must not have been called
+			expect(mockCloudflareClient.dns.records.update).not.toHaveBeenCalled();
+			// Cache is still written even on a no-op
+			expect((vi.mocked(env.DDNS_KV) as any).put).toHaveBeenCalled();
+			// No notification for unchanged records
+			expect(pushNtfyMock).toHaveBeenCalledWith([], env);
+		});
+
+		it('passes empty array to pushNtfy when no records changed', async () => {
+			const { pushNtfy } = await import('../src/pushNtfy');
+			const pushNtfyMock = vi.mocked(pushNtfy);
+
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+			mockCloudflareClient.dns.records.list.mockResolvedValue({
+				result: [{ id: 'r1', name: 'test.example.com', type: 'A', content: '5.5.5.5', proxied: false, ttl: 1 }],
+			} as any);
+
+			const request = createMockRequest('https://example.com/update?ip=5.5.5.5&hostname=test.example.com', {
+				headers: validAuth,
+			});
+
+			await worker.fetch(request, env);
+
+			expect(pushNtfyMock).toHaveBeenCalledWith([], env);
+		});
+
 		it('successfully updates multiple DNS records and sends a grouped notification', async () => {
 			const { pushNtfy } = await import('../src/pushNtfy');
 			const pushNtfyMock = vi.mocked(pushNtfy);
@@ -748,35 +1034,15 @@ describe('Worker fetch handler', () => {
 				result: [{ id: 'zone1', name: 'example.com' }],
 			} as any);
 
-			// First hostname
-			mockCloudflareClient.dns.records.list.mockResolvedValueOnce({
-				result: [
-					{
-						id: 'record1',
-						name: 'test1.example.com',
-						type: 'A',
-						content: '1.2.3.4',
-						proxied: false,
-						ttl: 1,
-					},
-				],
-			} as any);
+			mockCloudflareClient.dns.records.list
+				.mockResolvedValueOnce({
+					result: [{ id: 'record1', name: 'test1.example.com', type: 'A', content: '1.2.3.4', proxied: false, ttl: 1 }],
+				} as any)
+				.mockResolvedValueOnce({
+					result: [{ id: 'record2', name: 'test2.example.com', type: 'A', content: '1.2.3.4', proxied: true, ttl: 300 }],
+				} as any);
 
-			// Second hostname
-			mockCloudflareClient.dns.records.list.mockResolvedValueOnce({
-				result: [
-					{
-						id: 'record2',
-						name: 'test2.example.com',
-						type: 'A',
-						content: '1.2.3.4',
-						proxied: true,
-						ttl: 300,
-					},
-				],
-			} as any);
-
-			mockCloudflareClient.dns.records.update.mockResolvedValue({ success: true } as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
 			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=test1.example.com,test2.example.com', {
 				headers: validAuth,
@@ -810,7 +1076,7 @@ describe('Worker fetch handler', () => {
 					},
 				],
 			} as any);
-			mockCloudflareClient.dns.records.update.mockResolvedValue({ success: true } as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
 			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=test.example.com', {
 				headers: validAuth,
@@ -824,10 +1090,31 @@ describe('Worker fetch handler', () => {
 				zone_id: 'zone1',
 				name: 'test.example.com',
 				type: 'A',
-				proxied: false, // Default value
+				proxied: false,
 				comment: undefined,
-				ttl: 1, // Default value
+				ttl: 1,
 			});
+		});
+
+		it('calls pushNtfy exactly once per request that reaches the update phase', async () => {
+			const { pushNtfy } = await import('../src/pushNtfy');
+			const pushNtfyMock = vi.mocked(pushNtfy);
+
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+			mockCloudflareClient.dns.records.list.mockResolvedValue({
+				result: [{ id: 'r1', name: 'test.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }],
+			} as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: validAuth,
+			});
+
+			await worker.fetch(request, env);
+
+			expect(pushNtfyMock).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -839,7 +1126,7 @@ describe('Worker fetch handler', () => {
 		const validAuth = { Authorization: createAuthHeader('user@example.com', 'token') };
 
 		it('maps HttpError to the correct status code', async () => {
-			// Missing ip triggers a 422 HttpError from constructDNSRecord
+			// Missing ip triggers a 422 HttpError from constructDNSRecords
 			const request = createMockRequest('https://example.com/update', {
 				headers: validAuth,
 			});
@@ -888,6 +1175,29 @@ describe('Worker fetch handler', () => {
 				error: 'Internal Server Error',
 			});
 		});
+
+		it('success responses do not include a previousIp field', async () => {
+			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
+			(vi.mocked(env.DDNS_KV) as any).get.mockResolvedValue(null);
+			(vi.mocked(env.DDNS_KV) as any).put.mockResolvedValue(undefined);
+
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+			mockCloudflareClient.dns.records.list.mockResolvedValue({
+				result: [{ id: 'r1', name: 'test.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }],
+			} as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env);
+			const body = (await response.json()) as any;
+
+			expect(body.data).not.toHaveProperty('previousIp');
+		});
 	});
 
 	// -------------------------------------------------------------------------
@@ -901,7 +1211,8 @@ describe('Worker fetch handler', () => {
 			const validAuth = { Authorization: createAuthHeader('user@example.com', 'token') };
 
 			const kvMock = vi.mocked(env.DDNS_KV) as any;
-			kvMock.get.mockResolvedValue('1.2.3.4'); // Old IP stored in KV
+			// Old KV entry with different IP (cache miss by IP value)
+			kvMock.get.mockResolvedValue(JSON.stringify({ ip: '1.2.3.4', updatedAt: '2024-01-01T00:00:00.000Z' }));
 			kvMock.put.mockResolvedValue(undefined);
 
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
@@ -921,10 +1232,7 @@ describe('Worker fetch handler', () => {
 					},
 				],
 			} as any);
-			mockCloudflareClient.dns.records.update.mockResolvedValue({
-				success: true,
-				result: { id: 'record1' },
-			} as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
 			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=test.example.com', {
 				headers: validAuth,
@@ -938,104 +1246,42 @@ describe('Worker fetch handler', () => {
 				success: true,
 				message: 'DNS records updated successfully',
 				data: {
-					ip: '1.2.3.5',
-					previousIp: '1.2.3.4',
 					updated: true,
-					records: [{ hostname: 'test.example.com', type: 'A' }],
+					records: [{ hostname: 'test.example.com', type: 'A', ip: '1.2.3.5', updated: true }],
 				},
 			});
 
 			// Verify all pipeline steps ran
-			expect(kvMock.get).toHaveBeenCalledWith('ip:user@example.com');
+			expect(kvMock.get).toHaveBeenCalledWith('ip:test.example.com:A');
 			expect(mockCloudflareClient.user.tokens.verify).toHaveBeenCalled();
 			expect(mockCloudflareClient.zones.list).toHaveBeenCalled();
 			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalled();
 			expect(mockCloudflareClient.dns.records.update).toHaveBeenCalled();
-			expect(kvMock.put).toHaveBeenCalledWith('ip:user@example.com', '1.2.3.5');
+			expect(kvMock.put).toHaveBeenCalledWith('ip:test.example.com:A', expect.any(String), { expirationTtl: 2592000 });
 			expect(pushNtfyMock).toHaveBeenCalled();
 		});
 
-		it("falls back to 'unknown' as KV key when apiEmail is missing from client options", async () => {
-			const request = createMockRequest('https://example.com/update?ip=10.0.0.1&hostname=test.example.com', {
-				headers: { Authorization: createAuthHeader('user@example.com', 'api-token') },
-			});
-
-			// Delete apiEmail from the options passed to Cloudflare so updateHostnames
-			// hits the `?? 'unknown'` fallback.
-			// vitest 4: constructor mocks must use function/class form, not arrows
-			vi.mocked(Cloudflare).mockImplementation(function (options: any) {
-				delete options.apiEmail;
-				return mockCloudflareClient as any;
-			});
-
-			wireStandardHappyPath(mockCloudflareClient);
+		it('Bearer raw-token happy path: full update succeeds', async () => {
+			const { pushNtfy } = await import('../src/pushNtfy');
+			const pushNtfyMock = vi.mocked(pushNtfy);
 
 			const kvMock = vi.mocked(env.DDNS_KV) as any;
 			kvMock.get.mockResolvedValue(null);
 			kvMock.put.mockResolvedValue(undefined);
 
+			wireStandardHappyPath(mockCloudflareClient);
+
+			const request = createMockRequest('https://example.com/update?ip=10.0.0.1&hostname=test.example.com', {
+				headers: { Authorization: createBearerHeader('my-raw-api-token') },
+			});
+
 			const response = await worker.fetch(request, env);
 
 			expect(response.status).toBe(200);
+			expect(vi.mocked(Cloudflare)).toHaveBeenCalledWith({ apiToken: 'my-raw-api-token' });
 			const body = (await response.json()) as any;
 			expect(body.success).toBe(true);
-			expect(kvMock.put).toHaveBeenCalledWith('ip:unknown', '10.0.0.1');
-		});
-
-		it('handles undefined name/content on the returned record by using fallback strings', async () => {
-			const request = createMockRequest('https://example.com/update?ip=192.168.1.100&hostname=test.example.com', {
-				headers: { Authorization: createAuthHeader('user@example.com', 'api-token') },
-			});
-
-			wireStandardHappyPath(mockCloudflareClient);
-
-			const kvMock = vi.mocked(env.DDNS_KV) as any;
-			kvMock.get.mockResolvedValue(null);
-			kvMock.put.mockResolvedValue(undefined);
-
-			// Mock DNS update and verify the fallback logic for undefined properties
-			mockCloudflareClient.dns.records.update.mockImplementation(() => {
-				const newRecord: { name: string | undefined; type: string; content: string | undefined } = {
-					name: undefined,
-					type: 'A',
-					content: undefined,
-				};
-				const recordName = newRecord.name ?? 'unknown';
-				const recordContent = newRecord.content ?? '';
-				const successMsg = `DNS record for '${recordName}' ('${newRecord.type}') updated to '${recordContent}'`;
-
-				expect(recordName).toBe('unknown');
-				expect(recordContent).toBe('');
-				expect(successMsg).toContain('unknown');
-
-				return Promise.resolve(undefined);
-			});
-
-			const response = await worker.fetch(request, env);
-
-			expect(response.status).toBe(200);
-		});
-
-		it('does not store an empty string in KV when currentIp is non-empty', async () => {
-			const request = createMockRequest('https://example.com/update?ip=192.168.1.100&hostname=test.example.com', {
-				headers: { Authorization: createAuthHeader('user@example.com', 'api-token') },
-			});
-
-			wireStandardHappyPath(mockCloudflareClient);
-
-			const kvMock = vi.mocked(env.DDNS_KV) as any;
-			kvMock.get.mockResolvedValue(null);
-			kvMock.put.mockImplementation((_key: any, value: any) => {
-				// Guard against accidentally storing an empty IP
-				if (value === null || value === undefined || value === '') {
-					throw new Error('Should not store empty IP');
-				}
-				return Promise.resolve(undefined);
-			});
-
-			const response = await worker.fetch(request, env);
-
-			expect(response.status).toBe(200);
+			expect(pushNtfyMock).toHaveBeenCalledTimes(1);
 		});
 
 		it('returns 422 and skips KV storage when ip param is empty string', async () => {
@@ -1048,6 +1294,52 @@ describe('Worker fetch handler', () => {
 			expect(response.status).toBe(422);
 			const body = (await response.json()) as any;
 			expect(body.error).toBe("Missing 'ip' parameter. Use ip=auto to use the client IP.");
+		});
+
+		it('ip6 happy path: 2 hostnames + ip6 produces 4 records in the response', async () => {
+			const { pushNtfy } = await import('../src/pushNtfy');
+			const pushNtfyMock = vi.mocked(pushNtfy);
+
+			const kvMock = vi.mocked(env.DDNS_KV) as any;
+			kvMock.get.mockResolvedValue(null);
+			kvMock.put.mockResolvedValue(undefined);
+
+			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+
+			// 4 DNS record lookups: A for h1, AAAA for h1, A for h2, AAAA for h2
+			mockCloudflareClient.dns.records.list
+				.mockResolvedValueOnce({
+					result: [{ id: 'r1', name: 'h1.example.com', type: 'A', content: '0.0.0.0', proxied: false, ttl: 1 }],
+				} as any)
+				.mockResolvedValueOnce({
+					result: [{ id: 'r2', name: 'h1.example.com', type: 'AAAA', content: '::', proxied: false, ttl: 1 }],
+				} as any)
+				.mockResolvedValueOnce({
+					result: [{ id: 'r3', name: 'h2.example.com', type: 'A', content: '0.0.0.0', proxied: false, ttl: 1 }],
+				} as any)
+				.mockResolvedValueOnce({
+					result: [{ id: 'r4', name: 'h2.example.com', type: 'AAAA', content: '::', proxied: false, ttl: 1 }],
+				} as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+
+			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&ip6=2001:db8::1&hostname=h1.example.com,h2.example.com', {
+				headers: { Authorization: createAuthHeader('user', 'token') },
+			});
+
+			const response = await worker.fetch(request, env);
+			const body = (await response.json()) as any;
+
+			expect(response.status).toBe(200);
+			expect(body.data.records).toHaveLength(4);
+			// Both A and AAAA types present
+			const types = (body.data.records as any[]).map((r: any) => r.type as string);
+			expect(types.filter((t) => t === 'A')).toHaveLength(2);
+			expect(types.filter((t) => t === 'AAAA')).toHaveLength(2);
+			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledTimes(4);
+			expect(pushNtfyMock).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -71,7 +71,7 @@ describe('Worker fetch handler', () => {
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: createAuthHeader('user@example.com', 'valid-token') },
 			});
 
@@ -91,7 +91,7 @@ describe('Worker fetch handler', () => {
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: createAuthHeader('somedevice', 'mytoken') },
 			});
 
@@ -105,7 +105,7 @@ describe('Worker fetch handler', () => {
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: createBearerHeader('raw-api-token') },
 			});
 
@@ -116,7 +116,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		it('rejects request without Authorization header', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com');
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com');
 
 			const response = await worker.fetch(request, env);
 
@@ -129,7 +129,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		it('rejects request with empty Authorization header', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: '' },
 			});
 
@@ -141,7 +141,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		it('rejects request with unknown scheme', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: 'Digest abc123' },
 			});
 
@@ -153,7 +153,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		it('rejects request with scheme only (missing payload)', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: 'Basic' },
 			});
 
@@ -165,7 +165,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		it('rejects request with empty Bearer token', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: 'Bearer ' },
 			});
 
@@ -180,7 +180,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		it('rejects Basic with invalid base64 payload', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: 'Basic !!invalid!!base64!!' },
 			});
 
@@ -195,7 +195,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		it('rejects Basic where decoded value has no colon delimiter', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: `Basic ${btoa('nodelemiter')}` },
 			});
 
@@ -210,7 +210,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		it('rejects Basic where decoded value contains control characters', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: `Basic ${btoa('user:\x00token')}` },
 			});
 
@@ -225,7 +225,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		it('rejects Basic where token after colon is empty', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { Authorization: `Basic ${btoa('user:')}` },
 			});
 
@@ -240,7 +240,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		it('applies auth check to GET requests', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: { 'CF-Connecting-IP': '203.0.113.1' },
 			});
 
@@ -274,7 +274,7 @@ describe('Worker fetch handler', () => {
 	});
 
 	// -------------------------------------------------------------------------
-	// DNS record construction  (constructDNSRecords param validation)
+	// DNS record construction  (constructDNSRecords / resolveIps param validation)
 	// -------------------------------------------------------------------------
 
 	describe('DNS record construction', () => {
@@ -284,52 +284,162 @@ describe('Worker fetch handler', () => {
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
 		});
 
-		it('uses client IP when ip=auto', async () => {
+		it('uses client IPv4 when ip4=auto and CF-Connecting-IP contains a dot', async () => {
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=auto&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=auto&hostnames=test.example.com', {
 				headers: { ...validAuth, 'CF-Connecting-IP': '203.0.113.1' },
 			});
 
 			const response = await worker.fetch(request, env);
 
-			// Fails with 'No zones available' but confirms IP was resolved
+			// Fails with 'No zones available' but confirms IP was resolved and
+			// zones.list was reached (auth + param parsing both passed).
 			expect(response.status).toBe(400);
 		});
 
-		it('accepts myip parameter as alias for ip', async () => {
+		it('ip4=auto when client connected over IPv6 with ip6=auto also set produces only AAAA records', async () => {
+			mockCloudflareClient.zones.list.mockResolvedValue({
+				result: [{ id: 'zone1', name: 'example.com' }],
+			} as any);
+			mockCloudflareClient.dns.records.list.mockResolvedValue({
+				result: [{ id: 'r1', name: 'test.example.com', type: 'AAAA', content: '::', proxied: false, ttl: 1 }],
+			} as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+			(vi.mocked(env.DDNS_KV) as any).get.mockResolvedValue(null);
+			(vi.mocked(env.DDNS_KV) as any).put.mockResolvedValue(undefined);
+
+			// CF-Connecting-IP is an IPv6 address: ip4=auto slot is silently skipped,
+			// ip6=auto slot picks up the address.
+			const request = createMockRequest('https://example.com/update?ip4=auto&ip6=auto&hostnames=test.example.com', {
+				headers: { ...validAuth, 'CF-Connecting-IP': '2001:db8::1' },
+			});
+
+			const response = await worker.fetch(request, env);
+			const body = (await response.json()) as any;
+
+			expect(response.status).toBe(200);
+			// Only AAAA record was constructed and updated
+			expect(body.data.records).toHaveLength(1);
+			expect(body.data.records[0]).toMatchObject({ type: 'AAAA' });
+			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledWith(expect.objectContaining({ type: 'AAAA' }));
+		});
+
+		it('ip4=auto over IPv6 connection with no ip6 → 422 missing-IP', async () => {
+			// ip4=auto silently skips because CF-Connecting-IP contains ':',
+			// no ip6 is provided, so both slots end up null → 422.
+			const request = createMockRequest('https://example.com/update?ip4=auto&hostnames=test.example.com', {
+				headers: { ...validAuth, 'CF-Connecting-IP': '2001:db8::1' },
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(422);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: "Missing IP. Provide 'ip4' and/or 'ip6'; 'auto' uses the client IP.",
+			});
+		});
+
+		it('ip6=auto when client connected over IPv4 silently skips AAAA and falls through to ip4 only', async () => {
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?myip=1.2.3.4&hostname=test.example.com', {
+			// CF-Connecting-IP is IPv4: ip6=auto slot is silently skipped,
+			// ip4 literal is resolved, zones.list is reached.
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&ip6=auto&hostnames=test.example.com', {
+				headers: { ...validAuth, 'CF-Connecting-IP': '203.0.113.1' },
+			});
+
+			const response = await worker.fetch(request, env);
+
+			// Fails with 'No zones available' but confirms ip4 resolved and proceeded.
+			expect(response.status).toBe(400);
+			expect(mockCloudflareClient.zones.list).toHaveBeenCalled();
+		});
+
+		it('rejects ip4 literal that contains a colon (not a valid IPv4 address)', async () => {
+			const request = createMockRequest('https://example.com/update?ip4=2001:db8::1&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
 			const response = await worker.fetch(request, env);
 
-			// Fails with 'No zones available' but confirms parameter was accepted
-			expect(response.status).toBe(400);
+			expect(response.status).toBe(422);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: "The 'ip4' parameter must be a valid IPv4 address.",
+			});
 		});
 
-		it('accepts hostnames parameter as alias for hostname', async () => {
-			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
-
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostnames=test.example.com', {
+		it('rejects ip6 value that does not contain a colon', async () => {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&ip6=notanipv6&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
 			const response = await worker.fetch(request, env);
 
-			// Fails with 'No zones available' but confirms parameter was accepted
-			expect(response.status).toBe(400);
+			expect(response.status).toBe(422);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: "The 'ip6' parameter must be a valid IPv6 address.",
+			});
 		});
 
-		it('trims whitespace from ip parameter', async () => {
+		it('rejects request when neither ip4 nor ip6 is provided', async () => {
+			const request = createMockRequest('https://example.com/update?hostnames=test.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(422);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: "Missing IP. Provide 'ip4' and/or 'ip6'; 'auto' uses the client IP.",
+			});
+		});
+
+		it('rejects request without hostnames parameter', async () => {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(422);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: "Missing 'hostnames' parameter.",
+			});
+		});
+
+		it('rejects empty hostname list', async () => {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=,,,', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env);
+
+			expect(response.status).toBe(422);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: 'No hostnames provided.',
+			});
+		});
+
+		it('trims whitespace from ip4 parameter', async () => {
 			mockCloudflareClient.zones.list.mockResolvedValue({
 				result: [{ id: 'zone1', name: 'example.com' }],
 			} as any);
 			mockCloudflareClient.dns.records.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=%20%201.2.3.4%20&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=%20%201.2.3.4%20&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -345,7 +455,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=192.168.1.1&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=192.168.1.1&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -358,23 +468,28 @@ describe('Worker fetch handler', () => {
 			});
 		});
 
-		it('detects IPv6 address and queries for AAAA record', async () => {
+		it('ip6-only request (no ip4) produces only AAAA records', async () => {
 			mockCloudflareClient.zones.list.mockResolvedValue({
 				result: [{ id: 'zone1', name: 'example.com' }],
 			} as any);
-			mockCloudflareClient.dns.records.list.mockResolvedValue({ result: [] } as any);
+			mockCloudflareClient.dns.records.list.mockResolvedValue({
+				result: [{ id: 'r1', name: 'test.example.com', type: 'AAAA', content: '::', proxied: false, ttl: 1 }],
+			} as any);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+			(vi.mocked(env.DDNS_KV) as any).get.mockResolvedValue(null);
+			(vi.mocked(env.DDNS_KV) as any).put.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=2001:db8::1&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip6=2001:db8::1&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
-			await worker.fetch(request, env);
+			const response = await worker.fetch(request, env);
+			const body = (await response.json()) as any;
 
-			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledWith({
-				zone_id: 'zone1',
-				name: 'test.example.com',
-				type: 'AAAA',
-			});
+			expect(response.status).toBe(200);
+			expect(body.data.records).toHaveLength(1);
+			expect(body.data.records[0]).toMatchObject({ type: 'AAAA', ip: '2001:db8::1' });
+			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledWith(expect.objectContaining({ type: 'AAAA' }));
 		});
 
 		it('handles multiple hostnames separated by commas', async () => {
@@ -383,7 +498,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test1.example.com,test2.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test1.example.com,test2.example.com', {
 				headers: validAuth,
 			});
 
@@ -395,12 +510,12 @@ describe('Worker fetch handler', () => {
 			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledTimes(1);
 		});
 
-		it('adds an AAAA record per hostname when ip6 is provided alongside ip', async () => {
+		it('adds an AAAA record per hostname when ip6 is provided alongside ip4', async () => {
 			mockCloudflareClient.zones.list.mockResolvedValue({
 				result: [{ id: 'zone1', name: 'example.com' }],
 			} as any);
 
-			// A record for host1, AAAA for host1, A record for host2, AAAA for host2
+			// A for h1, AAAA for h1, A for h2, AAAA for h2
 			mockCloudflareClient.dns.records.list
 				.mockResolvedValueOnce({
 					result: [{ id: 'r1', name: 'h1.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }],
@@ -415,8 +530,10 @@ describe('Worker fetch handler', () => {
 					result: [{ id: 'r4', name: 'h2.example.com', type: 'AAAA', content: '::1', proxied: false, ttl: 1 }],
 				} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+			(vi.mocked(env.DDNS_KV) as any).get.mockResolvedValue(null);
+			(vi.mocked(env.DDNS_KV) as any).put.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&ip6=2001:db8::1&hostname=h1.example.com,h2.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&ip6=2001:db8::1&hostnames=h1.example.com,h2.example.com', {
 				headers: validAuth,
 			});
 
@@ -426,83 +543,8 @@ describe('Worker fetch handler', () => {
 			expect(response.status).toBe(200);
 			// 2 A records + 2 AAAA records = 4 entries
 			expect(body.data.records).toHaveLength(4);
-			// The four DNS record lookups ran
+			// All four DNS record lookups ran
 			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalledTimes(4);
-		});
-
-		it('rejects ip6 value that does not contain a colon', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&ip6=notanipv6&hostname=test.example.com', {
-				headers: validAuth,
-			});
-
-			const response = await worker.fetch(request, env);
-
-			expect(response.status).toBe(422);
-			const body = (await response.json()) as any;
-			expect(body).toEqual({
-				success: false,
-				error: "The 'ip6' parameter must be a valid IPv6 address.",
-			});
-		});
-
-		it('rejects request without ip parameter', async () => {
-			const request = createMockRequest('https://example.com/update?hostname=test.example.com', {
-				headers: validAuth,
-			});
-
-			const response = await worker.fetch(request, env);
-
-			expect(response.status).toBe(422);
-			const body = (await response.json()) as any;
-			expect(body).toEqual({
-				success: false,
-				error: "Missing 'ip' parameter. Use ip=auto to use the client IP.",
-			});
-		});
-
-		it('rejects ip=auto when CF-Connecting-IP is absent', async () => {
-			const request = new Request('https://example.com/update?ip=auto&hostname=test.example.com', {
-				headers: validAuth,
-			});
-
-			const response = await worker.fetch(request, env);
-
-			expect(response.status).toBe(500);
-			const body = (await response.json()) as any;
-			expect(body).toEqual({
-				success: false,
-				error: 'ip=auto specified but client IP could not be determined.',
-			});
-		});
-
-		it('rejects request without hostname parameter', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4', {
-				headers: validAuth,
-			});
-
-			const response = await worker.fetch(request, env);
-
-			expect(response.status).toBe(422);
-			const body = (await response.json()) as any;
-			expect(body).toEqual({
-				success: false,
-				error: "Missing 'hostname' parameter.",
-			});
-		});
-
-		it('rejects empty hostname list', async () => {
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=,,,', {
-				headers: validAuth,
-			});
-
-			const response = await worker.fetch(request, env);
-
-			expect(response.status).toBe(422);
-			const body = (await response.json()) as any;
-			expect(body).toEqual({
-				success: false,
-				error: 'No hostnames provided.',
-			});
 		});
 	});
 
@@ -517,7 +559,7 @@ describe('Worker fetch handler', () => {
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -530,7 +572,7 @@ describe('Worker fetch handler', () => {
 		it('rejects an inactive token', async () => {
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'expired' } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -561,7 +603,7 @@ describe('Worker fetch handler', () => {
 			// Cache contains a JSON entry with matching IP
 			kvMock.get.mockResolvedValue(JSON.stringify({ ip: '1.2.3.4', updatedAt: '2024-01-01T00:00:00.000Z' }));
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -594,7 +636,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -617,7 +659,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -636,7 +678,7 @@ describe('Worker fetch handler', () => {
 
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -653,7 +695,7 @@ describe('Worker fetch handler', () => {
 
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -676,7 +718,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -692,7 +734,7 @@ describe('Worker fetch handler', () => {
 
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -708,7 +750,7 @@ describe('Worker fetch handler', () => {
 
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -733,7 +775,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=h1.example.com,h2.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=h1.example.com,h2.example.com', {
 				headers: validAuth,
 			});
 
@@ -786,7 +828,7 @@ describe('Worker fetch handler', () => {
 
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=sub.test.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.5&hostnames=sub.test.com', {
 				headers: validAuth,
 			});
 
@@ -809,7 +851,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com&zone=example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com&zone=example.com', {
 				headers: validAuth,
 			});
 
@@ -826,7 +868,7 @@ describe('Worker fetch handler', () => {
 				result: [{ id: 'zone1', name: 'example.com' }],
 			} as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com&zone=notmine.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com&zone=notmine.com', {
 				headers: validAuth,
 			});
 
@@ -843,7 +885,7 @@ describe('Worker fetch handler', () => {
 		it('fails when no zones are available', async () => {
 			mockCloudflareClient.zones.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -863,7 +905,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.list.mockResolvedValue({ result: [] } as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -895,7 +937,7 @@ describe('Worker fetch handler', () => {
 				],
 			} as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.5&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -945,7 +987,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.5&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -987,7 +1029,7 @@ describe('Worker fetch handler', () => {
 				result: [{ id: 'r1', name: 'test.example.com', type: 'A', content: '1.2.3.4', proxied: false, ttl: 1 }],
 			} as any);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -1017,7 +1059,7 @@ describe('Worker fetch handler', () => {
 				result: [{ id: 'r1', name: 'test.example.com', type: 'A', content: '5.5.5.5', proxied: false, ttl: 1 }],
 			} as any);
 
-			const request = createMockRequest('https://example.com/update?ip=5.5.5.5&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=5.5.5.5&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -1044,7 +1086,7 @@ describe('Worker fetch handler', () => {
 
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=test1.example.com,test2.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.5&hostnames=test1.example.com,test2.example.com', {
 				headers: validAuth,
 			});
 
@@ -1078,7 +1120,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.5&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -1108,7 +1150,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -1126,8 +1168,8 @@ describe('Worker fetch handler', () => {
 		const validAuth = { Authorization: createAuthHeader('user@example.com', 'token') };
 
 		it('maps HttpError to the correct status code', async () => {
-			// Missing ip triggers a 422 HttpError from constructDNSRecords
-			const request = createMockRequest('https://example.com/update', {
+			// Missing ip4/ip6 triggers a 422 HttpError from resolveIps
+			const request = createMockRequest('https://example.com/update?hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -1137,14 +1179,14 @@ describe('Worker fetch handler', () => {
 			const body = (await response.json()) as any;
 			expect(body).toEqual({
 				success: false,
-				error: "Missing 'ip' parameter. Use ip=auto to use the client IP.",
+				error: "Missing IP. Provide 'ip4' and/or 'ip6'; 'auto' uses the client IP.",
 			});
 		});
 
 		it('maps unexpected errors to 500', async () => {
 			mockCloudflareClient.user.tokens.verify.mockRejectedValue(new Error('Network error'));
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -1162,7 +1204,7 @@ describe('Worker fetch handler', () => {
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ status: 'active' } as any);
 			mockCloudflareClient.zones.list.mockRejectedValue(new Error('API rate limit exceeded'));
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -1189,7 +1231,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -1234,7 +1276,7 @@ describe('Worker fetch handler', () => {
 			} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.5&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.5&hostnames=test.example.com', {
 				headers: validAuth,
 			});
 
@@ -1271,7 +1313,7 @@ describe('Worker fetch handler', () => {
 
 			wireStandardHappyPath(mockCloudflareClient);
 
-			const request = createMockRequest('https://example.com/update?ip=10.0.0.1&hostname=test.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=10.0.0.1&hostnames=test.example.com', {
 				headers: { Authorization: createBearerHeader('my-raw-api-token') },
 			});
 
@@ -1284,8 +1326,8 @@ describe('Worker fetch handler', () => {
 			expect(pushNtfyMock).toHaveBeenCalledTimes(1);
 		});
 
-		it('returns 422 and skips KV storage when ip param is empty string', async () => {
-			const request = createMockRequest('https://example.com/update?ip=&hostname=test.example.com', {
+		it('returns 422 and skips KV storage when ip4 param is empty string', async () => {
+			const request = createMockRequest('https://example.com/update?ip4=&hostnames=test.example.com', {
 				headers: { Authorization: createAuthHeader('user@example.com', 'api-token') },
 			});
 
@@ -1293,10 +1335,13 @@ describe('Worker fetch handler', () => {
 
 			expect(response.status).toBe(422);
 			const body = (await response.json()) as any;
-			expect(body.error).toBe("Missing 'ip' parameter. Use ip=auto to use the client IP.");
+			expect(body).toEqual({
+				success: false,
+				error: "Missing IP. Provide 'ip4' and/or 'ip6'; 'auto' uses the client IP.",
+			});
 		});
 
-		it('ip6 happy path: 2 hostnames + ip6 produces 4 records in the response', async () => {
+		it('ip4 + ip6 both literal: 2 hostnames produce 4 records in the response', async () => {
 			const { pushNtfy } = await import('../src/pushNtfy');
 			const pushNtfyMock = vi.mocked(pushNtfy);
 
@@ -1309,7 +1354,7 @@ describe('Worker fetch handler', () => {
 				result: [{ id: 'zone1', name: 'example.com' }],
 			} as any);
 
-			// 4 DNS record lookups: A for h1, AAAA for h1, A for h2, AAAA for h2
+			// A for h1, AAAA for h1, A for h2, AAAA for h2
 			mockCloudflareClient.dns.records.list
 				.mockResolvedValueOnce({
 					result: [{ id: 'r1', name: 'h1.example.com', type: 'A', content: '0.0.0.0', proxied: false, ttl: 1 }],
@@ -1325,7 +1370,7 @@ describe('Worker fetch handler', () => {
 				} as any);
 			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
 
-			const request = createMockRequest('https://example.com/update?ip=1.2.3.4&ip6=2001:db8::1&hostname=h1.example.com,h2.example.com', {
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&ip6=2001:db8::1&hostnames=h1.example.com,h2.example.com', {
 				headers: { Authorization: createAuthHeader('user', 'token') },
 			});
 


### PR DESCRIPTION
Closes #151.

## Auth: DNS-scoped tokens only

The worker authenticates with the API token alone. `Basic base64(username:token)` works exactly as UniFi sends it, but the username is ignored; raw `Bearer <token>` is accepted for direct callers. The Cloudflare SDK never receives an email (it only ever paired one with the legacy global key, so the email was always dead weight for auth).

## Address parameters: explicit ip4/ip6

`ip`, `myip`, and singular `hostname` are gone. The contract is now symmetric and explicit:

- `ip4=<address|auto>`: literal must be IPv4; `auto` uses the connecting IP when it arrived over IPv4 and silently skips A records otherwise
- `ip6=<address|auto>`: same, for IPv6/AAAA
- At least one slot must resolve; dual-stack callers get both record types per hostname in one request
- `hostnames=` takes the comma-separated list (separator stays comma: hostnames cannot contain one)
- `zone=<name>` optionally restricts record matching to one zone; multi-zone discovery remains the default

The `auto` family-matching makes dual-stack UniFi work without an IPv6 substitution variable: the UDM URL is `/update?ip4=%i&ip6=auto&hostnames=%h`.

## KV redesign: per-record cache with TTL

- Keys: `ip:<hostname>:<recordType>` (was `ip:<email>`); values: JSON `{ip, updatedAt}`; every write sets a 30-day `expirationTtl`, so stale identities can never accumulate again (the original #151 complaint)
- The skip decision is per record: requests where every record matches its cache return without touching the zones API; partially cached requests only process the pending records
- This also fixes a real bug: adding a new hostname while your IP was unchanged previously skipped the new hostname's first update entirely
- DNS is the source of truth: when the live record already holds the target IP, no update call is made and no notification fires; the cache refreshes silently

## Required config change (Zach)

UniFi Server field changes from `ddns.quist.network/update?ip=%i&hostnames=%h` to:

```
ddns.quist.network/update?ip4=%i&ip6=auto&hostnames=%h
```

Username can stay as-is (now ignored). Password (API token) unchanged.

## Migration

Legacy `last_ip` and `ip:<email>` keys in `kv-uddns-cache-prod` are never read again and have no TTL. One-time sweep after merge:

```sh
bun x wrangler kv key list --namespace-id 15acfe9ae3fa42448e902e7ee097d6ee --remote
bun x wrangler kv key delete <key> --namespace-id 15acfe9ae3fa42448e902e7ee097d6ee --remote
```

Wiping the namespace entirely is also safe; it is a pure cache now.

## Breaking changes

- `ip`, `myip`, and `hostname` query parameters removed; use `ip4`/`ip6`/`hostnames`
- The `ip=auto` 500-on-undeterminable behavior is gone; `auto` slots skip on family mismatch, and a request with no resolvable slot is a 422
- Authorization must be `Basic` (as UniFi sends) or raw `Bearer <token>`
- JSON responses drop `previousIp`; `data.records` entries carry per-record `updated` flags
