### PR TITLE
fix: drop smart placement so the rate limiter and fast path stay edge-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The worker is built to take heavy public traffic cheaply:
 
 - **Steady-state polling is API-free.** With the access key configured, a request whose records all match the KV cache answers with zero Cloudflare API calls: one worker invocation, one rate-limit check, and one KV read per record. A device polling every 2 minutes costs ~22k invocations and ~44k KV reads per month per record pair, far inside the Workers paid plan's included 10M requests and 10M KV reads.
 - **Cache misses stay lean.** Token verification and the zone list (cached per token for 5 minutes) front a parallel record lookup; only records whose DNS content actually differs trigger an update call. Audit writes and notifications ride `ctx.waitUntil` after the response.
-- **Strangers are throttled at the edge.** The rate limiter (50 requests/minute per IP, per colo) returns 429 before authentication runs, and an unauthenticated or wrong-key request never reaches the Cloudflare API, KV, or D1.
+- **Strangers are throttled at the edge.** The rate limiter (50 requests/minute per IP, per colo) returns 429 before authentication runs, and an unauthenticated or wrong-key request never reaches the Cloudflare API, KV, or D1. Enforcement is Cloudflare's best-effort, eventually-consistent counter, a cost cap against sustained abuse rather than a precise gate; short bursts can overshoot.
 - **Ballpark beyond included quotas** (Workers paid plan pricing): ~$0.30 per additional 1M requests, ~$0.50 per additional 1M KV reads; D1 audit volume is negligible by design (rows only on actual DNS-touching events).
 
 ## 🛠️ **Testing & Troubleshooting**

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -52,9 +52,8 @@
 		"enabled": true,
 	},
 
-	// Automatically place workloads in an optimal location to minimize latency.
-	// Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/
-	"placement": {
-		"mode": "smart",
-	},
+	// Deliberately NO smart placement: the hot path (gated cache hit) is
+	// KV-only and belongs at the ingress colo, and the rate limiter's
+	// per-machine counters only cohere when execution stays there. Only rare
+	// cache-miss paths talk to the Cloudflare API.
 }


### PR DESCRIPTION
Live verification of #168 found the 50/min rate limiter passing 120 parallel over-limit requests. Root cause: smart placement relocates execution off the ingress colo, fragmenting the limiter's per-machine counters (docs: counters are cached on the worker's machine, per location). Removing placement keeps the KV-only fast path at the edge (faster for the 99% case) and gives the limiter coherent counters; only rare cache-miss paths benefit from API proximity. README wording softened to the documented best-effort semantics. Will re-test the burst behavior live after deploy.