### PR TITLE
chore: clarify CUSTOM_DOMAIN config comments (CI-managed domain)

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -8,9 +8,9 @@ KV_NAMESPACE_ID=REPLACE_WITH_YOUR_KV_NAMESPACE_ID
 KV_NAMESPACE_PREVIEW_ID=REPLACE_WITH_YOUR_PREVIEW_KV_NAMESPACE_ID
 D1_DATABASE_ID=REPLACE_WITH_YOUR_D1_DATABASE_ID
 
-# Optional: attach a custom domain on a LOCAL `bun run deploy` (your wrangler
-# login has the zone access CI does not). Attached once, it persists across
-# later deploys. Without it the worker is served at its workers.dev URL.
+# Optional: attach a custom domain. Set the same value as a CUSTOM_DOMAIN
+# GitHub secret to manage it from CI. Without it the worker is served at its
+# workers.dev URL.
 # CUSTOM_DOMAIN=ddns.example.com
 
 # Optional: synced to the worker as a secret on every deploy when present.

--- a/.env.local.template
+++ b/.env.local.template
@@ -8,8 +8,9 @@ KV_NAMESPACE_ID=REPLACE_WITH_YOUR_KV_NAMESPACE_ID
 KV_NAMESPACE_PREVIEW_ID=REPLACE_WITH_YOUR_PREVIEW_KV_NAMESPACE_ID
 D1_DATABASE_ID=REPLACE_WITH_YOUR_D1_DATABASE_ID
 
-# Optional: attach a custom domain to the worker at deploy time. Use your
-# own domain; without this the worker is served at its workers.dev URL.
+# Optional: attach a custom domain on a LOCAL `bun run deploy` (your wrangler
+# login has the zone access CI does not). Attached once, it persists across
+# later deploys. Without it the worker is served at its workers.dev URL.
 # CUSTOM_DOMAIN=ddns.example.com
 
 # Optional: synced to the worker as a secret on every deploy when present.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,4 +36,5 @@ jobs:
           KV_NAMESPACE_ID: ${{ secrets.KV_NAMESPACE_ID }}
           KV_NAMESPACE_PREVIEW_ID: ${{ secrets.KV_NAMESPACE_PREVIEW_ID }}
           D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+          CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,5 +36,4 @@ jobs:
           KV_NAMESPACE_ID: ${{ secrets.KV_NAMESPACE_ID }}
           KV_NAMESPACE_PREVIEW_ID: ${{ secrets.KV_NAMESPACE_PREVIEW_ID }}
           D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
-          CUSTOM_DOMAIN: ${{ secrets.CUSTOM_DOMAIN }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,11 +5,9 @@
 	"compatibility_date": "2026-06-01",
 	"compatibility_flags": ["nodejs_compat"],
 
-	// No custom domain is hardcoded here: it is deployment-specific (you'd
-	// use your own domain, not anyone else's). Set CUSTOM_DOMAIN in your
-	// environment and `bun run deploy` injects it as a custom_domain route.
-	// Without it, the worker is reachable at its <name>.<subdomain>.workers.dev
-	// URL, and you can attach a domain in the Cloudflare dashboard.
+	// Attach a custom domain with `CUSTOM_DOMAIN=your.domain bun run deploy`
+	// (local; your wrangler login has the zone access). Otherwise the worker
+	// is reachable at its <name>.<subdomain>.workers.dev URL.
 
 	// account_id is intentionally absent: wrangler reads CLOUDFLARE_ACCOUNT_ID
 	// from the environment (GitHub Actions secret in CI, .env.local locally).

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,9 +5,9 @@
 	"compatibility_date": "2026-06-01",
 	"compatibility_flags": ["nodejs_compat"],
 
-	// Attach a custom domain with `CUSTOM_DOMAIN=your.domain bun run deploy`
-	// (local; your wrangler login has the zone access). Otherwise the worker
-	// is reachable at its <name>.<subdomain>.workers.dev URL.
+	// Set CUSTOM_DOMAIN to attach a custom domain; the deploy injects it as a
+	// custom_domain route. Otherwise the worker is served at its
+	// <name>.<subdomain>.workers.dev URL.
 
 	// account_id is intentionally absent: wrangler reads CLOUDFLARE_ACCOUNT_ID
 	// from the environment (GitHub Actions secret in CI, .env.local locally).


### PR DESCRIPTION
Net effect vs main: comment-only cleanup around the custom-domain injection. CI manages the domain via the CUSTOM_DOMAIN secret; deploy.ts injects it as a custom_domain route. Requires Zone -> Workers Routes -> Edit on the deploy token (scoped to the zone) for the route to apply.