### PR TITLE
fix(security): pin CI actions by SHA and bound the update fan-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -66,7 +66,7 @@ jobs:
 
       - name: Report coverage
         if: always()
-        uses: davelosert/vitest-coverage-report-action@v2.12.2
+        uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2.12.2
 
   build:
     name: Deploy Dry Run
@@ -74,10 +74,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -91,12 +91,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -107,7 +107,7 @@ jobs:
       # On push to main, base == HEAD and the diff scan would no-op.
       - name: Scan for secrets
         if: github.event_name == 'pull_request'
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ injected at deploy time from the environment.
    - **Username:** Your `ACCESS_KEY` if you configured one (recommended); any value otherwise (the field is never used for authentication)
    - **Password:** Cloudflare User API Token scoped to DNS edit _(not an Account API Token)_
    - **Server:** `<worker-name>.<worker-subdomain>.workers.dev/update?ip4=%i&ip6=auto&hostnames=%h`
-     _(Omit `https://`. Comma-separate to update several records at once: `hostnames=example.com,*.example.com`. `ip4`/`ip6` each accept a literal address or `auto`, which uses the connecting IP when it matches that family and skips the slot otherwise; provide at least one. Optional `zone=example.com` restricts matching to one zone. Optional `ntfy=` sends change notifications to your ntfy server, pasted raw: `ntfy=https://ntfy.sh/my-topic`. Do not percent-encode it; inadyn treats `%` sequences as its own substitution variables.)_
+     _(Omit `https://`. Comma-separate to update several records at once: `hostnames=example.com,*.example.com`. A request carries up to 40 records, and each hostname counts once per IP family, so 40 hostnames with `ip4` alone or 20 with both. Batches near that size need the paid Workers plan; the free plan's 50-subrequest ceiling fits roughly six records. `ip4`/`ip6` each accept a literal address or `auto`, which uses the connecting IP when it matches that family and skips the slot otherwise; provide at least one. Optional `zone=example.com` restricts matching to one zone. Optional `ntfy=` sends change notifications to your ntfy server, pasted raw: `ntfy=https://ntfy.sh/my-topic`. Do not percent-encode it; inadyn treats `%` sequences as its own substitution variables.)_
 
 ## 📜 **Audit History**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,19 @@ interface UpdateRequest {
 
 const NTFY_URL_MAX_LENGTH = 512;
 
+// The bound is on records, not hostnames, because the ip4 and ip6 slots each
+// turn one hostname into a record and the cost follows records. One record
+// spends a KV read, a records.list per candidate zone, an update when the IP
+// moved, and a KV write, so 40 stays inside the 1000 subrequest ceiling even
+// with several nested zones on the token. Batches this size need the paid
+// plan; the free ceiling of 50 subrequests fits roughly six records.
+const RECORDS_MAX = 40;
+
+// RFC 1035: 253 characters for a full domain name. An over-long name also
+// pushes the KV key past its own limit, which turns the cache into a
+// permanent miss for that record.
+const HOSTNAME_MAX_LENGTH = 253;
+
 /**
  * Validates the caller-supplied ntfy URL. Any https endpoint is allowed
  * (self-hosted servers included): the notification body is worker-built
@@ -252,12 +265,23 @@ function constructDNSRecords(request: Request): UpdateRequest {
 	if (hostnameParam === null || hostnameParam === '') {
 		throw new HttpError(422, "Missing 'hostnames' parameter.");
 	}
-	const hostnames = hostnameParam
-		.split(',')
-		.map((s) => s.trim())
-		.filter(Boolean);
+	// Deduplicated: a repeated hostname would otherwise fan out into one
+	// concurrent update per copy, all racing the same record, and file an
+	// audit row per copy for a single logical change.
+	const hostnames = [
+		...new Set(
+			hostnameParam
+				.split(',')
+				.map((s) => s.trim())
+				.filter(Boolean),
+		),
+	];
 	if (hostnames.length === 0) {
 		throw new HttpError(422, 'No hostnames provided.');
+	}
+	const overlong = hostnames.find((hostname) => hostname.length > HOSTNAME_MAX_LENGTH);
+	if (overlong !== undefined) {
+		throw new HttpError(422, `Hostname exceeds ${String(HOSTNAME_MAX_LENGTH)} characters: '${overlong.slice(0, 60)}...'`);
 	}
 
 	// Per hostname: an A record when ip4 resolved, an AAAA when ip6 did.
@@ -269,6 +293,12 @@ function constructDNSRecords(request: Request): UpdateRequest {
 		if (v6 !== null) {
 			records.push({ content: v6, name: hostname, type: 'AAAA', ttl: 1 });
 		}
+	}
+	if (records.length > RECORDS_MAX) {
+		throw new HttpError(
+			422,
+			`Too many DNS records: ${String(records.length)} requested, ${String(RECORDS_MAX)} allowed per request. Each hostname counts once per IP family.`,
+		);
 	}
 
 	return { records, zoneFilter: zoneFilter === '' ? null : zoneFilter, ntfyUrl };
@@ -322,6 +352,11 @@ async function verifyToken(cloudflare: Cloudflare): Promise<string> {
 	}
 	if (verification.status !== 'active') {
 		throw new HttpError(401, `Authentication failed: token ${verification.status}`);
+	}
+	// The ID keys the zone cache and the audit rows' tenant column, so an
+	// absent or empty one would pool separate tenants under a shared key.
+	if (typeof verification.id !== 'string' || verification.id === '') {
+		throw new HttpError(401, 'Authentication failed: token has no identity.');
 	}
 	return verification.id;
 }
@@ -503,7 +538,18 @@ async function updateHostnames(
 	const { records, zoneFilter, ntfyUrl } = updateRequest;
 	const cloudflare = apiClient(auth);
 
-	// Cache reads are KV-only and decide whether any API work exists at all.
+	// With the gate off the token is the only credential, so it is verified
+	// before any KV work: an unverified caller costs one API call, not one KV
+	// read per record. With the gate on, ACCESS_KEY has already filtered
+	// strangers, so a full cache hit answers with zero Cloudflare API calls.
+	//
+	// ACCESS_KEY is one shared deployment secret, not a per-caller identity,
+	// and the IP cache is keyed by hostname alone. Anyone holding it can
+	// therefore confirm a cached IP for a hostname they do not control. The
+	// fast path also stays unaudited by design, because nothing was touched.
+	const gated = Boolean(env.ACCESS_KEY);
+	let tokenId = gated ? null : await verifyToken(cloudflare);
+
 	const cachedIps = await Promise.all(records.map(async (record) => readCachedIp(env, record)));
 	const pending = records.filter((record, i) => cachedIps[i] !== record.content);
 
@@ -522,19 +568,11 @@ async function updateHostnames(
 		);
 	};
 
-	// With the access gate on, the caller is already authenticated, so a full
-	// cache hit answers with ZERO Cloudflare API calls. Without the gate,
-	// verify first so unauthenticated probes can't use the fast path as an
-	// oracle. The fast path stays unaudited by design: nothing was touched.
-	const gated = Boolean(env.ACCESS_KEY);
-	if (gated && pending.length === 0) {
-		return allCurrentResponse();
-	}
-
-	const tokenId = await verifyToken(cloudflare);
 	if (pending.length === 0) {
 		return allCurrentResponse();
 	}
+
+	tokenId ??= await verifyToken(cloudflare);
 
 	let zones = await readCachedZones(env, tokenId);
 	if (zones === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,14 @@ interface CachedIp {
 	updatedAt: string;
 }
 
-function cacheKey(record: DDNSRecord): string {
-	return `${KV_KEY_PREFIX}:${record.name}:${record.type}`;
+/**
+ * Cache keys carry the token ID so a caller only ever reads back entries
+ * their own token wrote. A hostname-only key would let any valid token read
+ * the cached IP for a name it has no authority over, which for a proxied
+ * record is the origin address rather than anything DNS would resolve.
+ */
+function cacheKey(tokenId: string, record: DDNSRecord): string {
+	return `${KV_KEY_PREFIX}:${tokenId}:${record.name}:${record.type}`;
 }
 
 export class HttpError extends Error {
@@ -305,25 +311,27 @@ function constructDNSRecords(request: Request): UpdateRequest {
 }
 
 /** Reads a record's cached IP; any failure or unparseable entry is a miss. */
-async function readCachedIp(env: Env, record: DDNSRecord): Promise<string | null> {
+async function readCachedIp(env: Env, tokenId: string, record: DDNSRecord): Promise<string | null> {
+	const key = cacheKey(tokenId, record);
 	try {
-		const raw = await env.DDNS_KV.get(cacheKey(record));
+		const raw = await env.DDNS_KV.get(key);
 		if (raw === null) return null;
 		const parsed = JSON.parse(raw) as Partial<CachedIp>;
 		return typeof parsed.ip === 'string' ? parsed.ip : null;
 	} catch (error) {
-		console.error(`Failed to read IP cache for ${cacheKey(record)}:`, error);
+		console.error(`Failed to read IP cache for ${key}:`, error);
 		return null;
 	}
 }
 
 /** Caches a record's IP with a TTL so stale entries clean themselves up. */
-async function writeCachedIp(env: Env, record: DDNSRecord): Promise<void> {
+async function writeCachedIp(env: Env, tokenId: string, record: DDNSRecord): Promise<void> {
 	const value: CachedIp = { ip: record.content, updatedAt: new Date().toISOString() };
+	const key = cacheKey(tokenId, record);
 	try {
-		await env.DDNS_KV.put(cacheKey(record), JSON.stringify(value), { expirationTtl: KV_TTL_SECONDS });
+		await env.DDNS_KV.put(key, JSON.stringify(value), { expirationTtl: KV_TTL_SECONDS });
 	} catch (error) {
-		console.error(`Failed to write IP cache for ${cacheKey(record)}:`, error);
+		console.error(`Failed to write IP cache for ${key}:`, error);
 		// The cache is an optimization; the update already succeeded.
 	}
 }
@@ -510,7 +518,7 @@ async function processRecord(
 		console.log(`DNS record for '${record.name}' ('${record.type}') already at '${record.content}'. Refreshing cache only.`);
 	}
 
-	await writeCachedIp(env, record);
+	await writeCachedIp(env, tokenId, record);
 	return {
 		record,
 		result: { hostname: record.name, type: record.type, ip: record.content, updated: changed },
@@ -538,19 +546,14 @@ async function updateHostnames(
 	const { records, zoneFilter, ntfyUrl } = updateRequest;
 	const cloudflare = apiClient(auth);
 
-	// With the gate off the token is the only credential, so it is verified
-	// before any KV work: an unverified caller costs one API call, not one KV
-	// read per record. With the gate on, ACCESS_KEY has already filtered
-	// strangers, so a full cache hit answers with zero Cloudflare API calls.
-	//
-	// ACCESS_KEY is one shared deployment secret, not a per-caller identity,
-	// and the IP cache is keyed by hostname alone. Anyone holding it can
-	// therefore confirm a cached IP for a hostname they do not control. The
-	// fast path also stays unaudited by design, because nothing was touched.
-	const gated = Boolean(env.ACCESS_KEY);
-	let tokenId = gated ? null : await verifyToken(cloudflare);
+	// Verification comes first on every path: it names the cache partition, and
+	// it keeps an unverified caller at one API call rather than one KV read per
+	// record. The cached fast path below therefore costs one verify call, which
+	// is the price of never serving one caller's cache entry to another.
+	// That path stays unaudited by design, because nothing was touched.
+	const tokenId = await verifyToken(cloudflare);
 
-	const cachedIps = await Promise.all(records.map(async (record) => readCachedIp(env, record)));
+	const cachedIps = await Promise.all(records.map(async (record) => readCachedIp(env, tokenId, record)));
 	const pending = records.filter((record, i) => cachedIps[i] !== record.content);
 
 	const allCurrentResponse = (): Response => {
@@ -571,8 +574,6 @@ async function updateHostnames(
 	if (pending.length === 0) {
 		return allCurrentResponse();
 	}
-
-	tokenId ??= await verifyToken(cloudflare);
 
 	let zones = await readCachedZones(env, tokenId);
 	if (zones === null) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -437,22 +437,28 @@ describe('Worker fetch handler', () => {
 			expect(order).toEqual(['verify']);
 		});
 
-		it('answers a full cache hit with no API call when ACCESS_KEY is set', async () => {
-			// The gate already authenticated the caller, so the cached fast path
-			// stays free of Cloudflare calls.
+		it('does not serve one token a cache entry another token wrote', async () => {
+			// A shared ACCESS_KEY is one deployment secret, not a per-caller
+			// identity, so without partitioning the fast path would confirm a
+			// cached IP to anyone holding it. For a proxied record that value is
+			// the origin address.
 			env.ACCESS_KEY = 'secret-key';
-			(vi.mocked(env.DDNS_KV) as any).get.mockResolvedValue(JSON.stringify({ ip: '1.2.3.4', updatedAt: '2024-01-01T00:00:00.000Z' }));
+			const victimKey = 'ip:victim-token:vpn.example.com:A';
+			const storage = new Map([[victimKey, JSON.stringify({ ip: '203.0.113.77', updatedAt: '2024-01-01T00:00:00.000Z' })]]);
+			(vi.mocked(env.DDNS_KV) as any).get.mockImplementation((key: string) => Promise.resolve(storage.get(key) ?? null));
+			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ id: 'attacker-token', status: 'active' } as any);
+			mockCloudflareClient.zones.list.mockReturnValue(mockPage({ result: [] }));
 
-			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
-				headers: { Authorization: createAuthHeader('secret-key', 'token') },
+			const request = createMockRequest('https://example.com/update?ip4=203.0.113.77&hostnames=vpn.example.com', {
+				headers: { Authorization: createAuthHeader('secret-key', 'attacker-cf-token') },
 			});
 
 			const response = await worker.fetch(request, env, ctx);
 
-			expect(response.status).toBe(200);
-			const body = (await response.json()) as any;
-			expect(body.message).toBe('No IP change detected');
-			expect(mockCloudflareClient.user.tokens.verify).not.toHaveBeenCalled();
+			// A correct IP guess must not come back as the cached-and-current 200.
+			expect(response.status).toBe(400);
+			expect((vi.mocked(env.DDNS_KV) as any).get).toHaveBeenCalledWith('ip:attacker-token:vpn.example.com:A');
+			expect((vi.mocked(env.DDNS_KV) as any).get).not.toHaveBeenCalledWith(victimKey);
 		});
 
 		it('passes through when ACCESS_KEY is empty (open mode)', async () => {
@@ -1140,7 +1146,7 @@ describe('Worker fetch handler', () => {
 		});
 
 		// Gate ON (ACCESS_KEY non-empty): fast-path check runs before verify.
-		it('skips zone listing and tokens.verify when ALL records match cached IPs (gate on)', async () => {
+		it('stops at the token check when ALL records match cached IPs (gate on)', async () => {
 			env.ACCESS_KEY = 'gate-key';
 			const kvMock = vi.mocked(env.DDNS_KV) as any;
 			kvMock.get.mockResolvedValue(JSON.stringify({ ip: '1.2.3.4', updatedAt: '2024-01-01T00:00:00.000Z' }));
@@ -1161,12 +1167,14 @@ describe('Worker fetch handler', () => {
 					records: [{ hostname: 'test.example.com', type: 'A', ip: '1.2.3.4', updated: false }],
 				},
 			});
+			// The token check names the cache partition, so it is the one call a
+			// full cache hit still makes. Nothing beyond it runs.
+			expect(mockCloudflareClient.user.tokens.verify).toHaveBeenCalledTimes(1);
 			expect(mockCloudflareClient.zones.list).not.toHaveBeenCalled();
-			// Gate is on: verify must NOT be called on a full cache hit
-			expect(mockCloudflareClient.user.tokens.verify).not.toHaveBeenCalled();
+			expect(mockCloudflareClient.dns.records.list).not.toHaveBeenCalled();
 		});
 
-		it('uses cache key ip:<hostname>:<type>', async () => {
+		it('uses cache key ip:<tokenId>:<hostname>:<type>', async () => {
 			const kvMock = vi.mocked(env.DDNS_KV) as any;
 			kvMock.get.mockResolvedValue(null);
 			kvMock.put.mockResolvedValue(undefined);
@@ -1189,8 +1197,8 @@ describe('Worker fetch handler', () => {
 
 			await worker.fetch(request, env, ctx);
 
-			expect(kvMock.get).toHaveBeenCalledWith('ip:test.example.com:A');
-			expect(kvMock.put).toHaveBeenCalledWith('ip:test.example.com:A', expect.any(String), { expirationTtl: 2592000 });
+			expect(kvMock.get).toHaveBeenCalledWith('ip:tid:test.example.com:A');
+			expect(kvMock.put).toHaveBeenCalledWith('ip:tid:test.example.com:A', expect.any(String), { expirationTtl: 2592000 });
 		});
 
 		it('writes JSON {ip, updatedAt} to KV with expirationTtl 2592000', async () => {
@@ -2584,12 +2592,12 @@ describe('Worker fetch handler', () => {
 			});
 
 			// Verify all pipeline steps ran
-			expect(kvMock.get).toHaveBeenCalledWith('ip:test.example.com:A');
+			expect(kvMock.get).toHaveBeenCalledWith('ip:token-id-123:test.example.com:A');
 			expect(mockCloudflareClient.user.tokens.verify).toHaveBeenCalled();
 			expect(mockCloudflareClient.zones.list).toHaveBeenCalled();
 			expect(mockCloudflareClient.dns.records.list).toHaveBeenCalled();
 			expect(mockCloudflareClient.dns.records.update).toHaveBeenCalled();
-			expect(kvMock.put).toHaveBeenCalledWith('ip:test.example.com:A', expect.any(String), { expirationTtl: 2592000 });
+			expect(kvMock.put).toHaveBeenCalledWith('ip:token-id-123:test.example.com:A', expect.any(String), { expirationTtl: 2592000 });
 			expect(waitUntilMock).toHaveBeenCalled();
 
 			// pushNtfy called after resolving waitUntil promises

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -413,6 +413,48 @@ describe('Worker fetch handler', () => {
 	// -------------------------------------------------------------------------
 
 	describe('Access gate', () => {
+		it('verifies the token before touching KV when no ACCESS_KEY is set', async () => {
+			// The token is the only credential in open mode, so an unverified
+			// caller must not be able to spend a KV read per hostname first.
+			env.ACCESS_KEY = '';
+			const order: string[] = [];
+			mockCloudflareClient.user.tokens.verify.mockImplementation(() => {
+				order.push('verify');
+				return Promise.reject(new MockAuthenticationError());
+			});
+			(vi.mocked(env.DDNS_KV) as any).get.mockImplementation(() => {
+				order.push('kv');
+				return Promise.resolve(null);
+			});
+
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=a.example.com,b.example.com', {
+				headers: { Authorization: createAuthHeader('user', 'token') },
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+
+			expect(response.status).toBe(401);
+			expect(order).toEqual(['verify']);
+		});
+
+		it('answers a full cache hit with no API call when ACCESS_KEY is set', async () => {
+			// The gate already authenticated the caller, so the cached fast path
+			// stays free of Cloudflare calls.
+			env.ACCESS_KEY = 'secret-key';
+			(vi.mocked(env.DDNS_KV) as any).get.mockResolvedValue(JSON.stringify({ ip: '1.2.3.4', updatedAt: '2024-01-01T00:00:00.000Z' }));
+
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
+				headers: { Authorization: createAuthHeader('secret-key', 'token') },
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+
+			expect(response.status).toBe(200);
+			const body = (await response.json()) as any;
+			expect(body.message).toBe('No IP change detected');
+			expect(mockCloudflareClient.user.tokens.verify).not.toHaveBeenCalled();
+		});
+
 		it('passes through when ACCESS_KEY is empty (open mode)', async () => {
 			env.ACCESS_KEY = '';
 			mockCloudflareClient.user.tokens.verify.mockResolvedValue({ id: 'tid', status: 'active' } as any);
@@ -662,6 +704,84 @@ describe('Worker fetch handler', () => {
 			});
 		});
 
+		// The ceiling is on records, since each IP family turns one hostname
+		// into a record and every record carries its own fan-out cost.
+		it.each([
+			['single family at the ceiling', 40, 'ip4=1.2.3.4'],
+			['dual stack at the ceiling', 20, 'ip4=1.2.3.4&ip6=2001:db8::1'],
+		])('accepts %s', async (_label, count, ipParams) => {
+			const hostnames = Array.from({ length: count }, (_, i) => `h${String(i)}.example.com`).join(',');
+			mockCloudflareClient.zones.list.mockReturnValue(mockPage({ result: [{ id: 'zone1', name: 'example.com' }] }));
+			mockCloudflareClient.dns.records.list.mockReturnValue(mockPage({ result: [] }));
+
+			const request = createMockRequest(`https://example.com/update?${ipParams}&hostnames=${hostnames}`, {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+			const body = (await response.json()) as any;
+
+			// Refused for having no matching record, not for its size.
+			expect(response.status).toBe(400);
+			expect(body.error).toContain('No matching record found');
+		});
+
+		it.each([
+			['single family', 41, 'ip4=1.2.3.4', 41],
+			['dual stack', 21, 'ip4=1.2.3.4&ip6=2001:db8::1', 42],
+		])('rejects %s past the record ceiling before spending a KV read', async (_label, count, ipParams, records) => {
+			const hostnames = Array.from({ length: count }, (_, i) => `h${String(i)}.example.com`).join(',');
+
+			const request = createMockRequest(`https://example.com/update?${ipParams}&hostnames=${hostnames}`, {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+
+			expect(response.status).toBe(422);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: `Too many DNS records: ${String(records)} requested, 40 allowed per request. Each hostname counts once per IP family.`,
+			});
+			expect((vi.mocked(env.DDNS_KV) as any).get).not.toHaveBeenCalled();
+		});
+
+		it('collapses a repeated hostname into one record', async () => {
+			// Undeduplicated, each copy races the same DNS record with its own
+			// update call and files its own audit row for one logical change.
+			const hostnames = Array.from({ length: 30 }, () => 'test.example.com').join(',');
+			wireStandardHappyPath(mockCloudflareClient);
+			(vi.mocked(env.DDNS_KV) as any).get.mockResolvedValue(null);
+
+			const request = createMockRequest(`https://example.com/update?ip4=1.2.3.5&hostnames=${hostnames}`, {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+			const body = (await response.json()) as any;
+
+			expect(response.status).toBe(200);
+			expect(body.data.records).toHaveLength(1);
+			expect(mockCloudflareClient.dns.records.update).toHaveBeenCalledTimes(1);
+		});
+
+		it('rejects a hostname longer than a DNS name may be', async () => {
+			// An over-long name also pushes the KV cache key past its own limit.
+			const hostname = `${'a'.repeat(250)}.example.com`;
+
+			const request = createMockRequest(`https://example.com/update?ip4=1.2.3.4&hostnames=${hostname}`, {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+
+			expect(response.status).toBe(422);
+			const body = (await response.json()) as any;
+			expect(body.error).toContain('exceeds 253 characters');
+			expect((vi.mocked(env.DDNS_KV) as any).get).not.toHaveBeenCalled();
+		});
+
 		it('trims whitespace from ip4 parameter', async () => {
 			mockCloudflareClient.zones.list.mockReturnValue(
 				mockPage({
@@ -881,6 +1001,30 @@ describe('Worker fetch handler', () => {
 				success: false,
 				error: 'Authentication failed: token expired',
 			});
+		});
+
+		// The ID keys the zone cache and the audit rows' tenant column, so an
+		// active token without one must not reach either.
+		it.each([
+			['a missing id', { status: 'active' }],
+			['an empty id', { id: '', status: 'active' }],
+			['a non-string id', { id: 12345, status: 'active' }],
+		])('returns 401 when tokens.verify returns %s', async (_label, verification) => {
+			mockCloudflareClient.user.tokens.verify.mockResolvedValue(verification as any);
+
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=test.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+
+			expect(response.status).toBe(401);
+			const body = (await response.json()) as any;
+			expect(body).toEqual({
+				success: false,
+				error: 'Authentication failed: token has no identity.',
+			});
+			expect(mockCloudflareClient.zones.list).not.toHaveBeenCalled();
 		});
 
 		it('returns 401 when tokens.verify rejects with a BadRequestError', async () => {


### PR DESCRIPTION
Closes the two items flagged in #182's review, plus the cache oracle that review surfaced. None were introduced there.

## CI supply chain

`trufflesecurity/trufflehog@main` was a **branch** ref. Any push to that repository's default branch would execute in this repo's CI, in the `security` job, with a full checkout in hand. Tagged refs are mutable too and can be repointed.

Every `uses:` in both workflows now carries a commit SHA with the version in a trailing comment, which Dependabot keeps current via the existing `github-actions` ecosystem config:

| Action | Pin |
| --- | --- |
| `actions/checkout` | `3d3c42e` (v7.0.1) |
| `oven-sh/setup-bun` | `0c5077e` (v2.2.0) |
| `davelosert/vitest-coverage-report-action` | `8b15768` (v2.12.2) |
| `trufflesecurity/trufflehog` | `6f3c981` (v3.96.0) |

`deploy.yml` is the one that matters most: that job holds the Cloudflare API token, account ID, and `ACCESS_KEY`.

## Update fan-out

`hostnames` had no ceiling. A caller could split four figures of names out of one URL, and each cost two KV reads *before* `verifyToken` ran. With `ACCESS_KEY` unset, any request reached that fan-out, and it exceeded the per-invocation subrequest limit, so the cost landed on the operator for a request that could only ever 500.

**Ordering.** Verification now runs before any KV work on every path. An unverified caller costs one API call instead of one KV read per record.

**Ceiling.** Counts records, not hostnames, because each IP family expands a hostname into its own record and cost follows records. Measured against the worker, 50 hostnames dual-stack across three nested zones was 605 subrequests, so the original hostname-based cap was sized wrong. 40 records keeps the worst case well inside the paid budget. That is 40 hostnames with `ip4` alone, or 20 with both.

**Deduplication.** 50 copies of one hostname previously became 50 concurrent updates racing a single DNS record, 50 audit rows for one logical change, and a nondeterministic `previousIp`.

**Length.** A name over 253 characters (RFC 1035) is refused rather than left to overflow its own KV cache key, which would otherwise make that record a permanent cache miss.

## Cache partitioning

The IP cache key was `ip:<hostname>:<type>`, shared across all callers, and the fast path returned before any check that the caller controlled the hostname. Anyone with a valid Cloudflare token could submit a guessed IP for someone else's hostname and read the answer off the status code: 200 for a hit, 400 or 401 for a miss. For a proxied record the cached value is the origin address, which is precisely what proxying hides.

The key is now `ip:<tokenId>:<hostname>:<type>`, so a lookup can only confirm an IP the caller already set.

The tradeoff: that key is known only after verification, so a gated full cache hit now costs one verify call where it previously cost none. It still reaches neither `zones.list` nor `dns.records.list`. Existing entries under the old key are never read again and age out on the 30-day TTL; each record takes one extra DNS round trip the first time it is seen after deploy.

## Also

`verifyToken` rejects an active token carrying no usable ID. That ID keys the zone cache and the audit rows' tenant column, so an empty one would write under a shared `zones:` key and pool separate tenants.

## Verification

156 tests at 100% coverage, `bun audit` clean, deploy dry run builds. New cases cover both cap dimensions, deduplication, the length limit, verification ordering, the missing-ID paths, and cross-token cache isolation. The isolation test was confirmed to fail against the un-partitioned key before the fix landed.

## Known, not fixed here

A mid-batch failure still discards audit rows for records that did change, since `writeAuditEvents` sits on the success side of a `Promise.all`. Pre-existing, and the record ceiling reduces the maximum exposure rather than adding to it.