### PR TITLE
fix(audit): record and report a batch that applies partially

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,12 @@ const RECORDS_MAX = 40;
 // permanent miss for that record.
 const HOSTNAME_MAX_LENGTH = 253;
 
+// Letters, digits and hyphens per label, with an optional wildcard leader.
+// Query parameters arrive percent-decoded, so without this a newline inside
+// a hostname reaches the log lines that quote it. IDNs belong here in their
+// punycode form, which is what the Cloudflare API expects anyway.
+const HOSTNAME_PATTERN = /^(\*\.)?[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
+
 /**
  * Validates the caller-supplied ntfy URL. Any https endpoint is allowed
  * (self-hosted servers included): the notification body is worker-built
@@ -87,6 +93,12 @@ export class HttpError extends Error {
 	constructor(
 		public readonly statusCode: number,
 		message: string,
+		/**
+		 * Records that already reached DNS when a batch failed part-way. The
+		 * response carries them so a caller reading only the status never
+		 * concludes that nothing changed.
+		 */
+		public readonly applied: RecordResult[] = [],
 	) {
 		super(message);
 		this.name = new.target.name;
@@ -117,7 +129,17 @@ interface HistoryResponseBody {
 	};
 }
 
-function jsonResponse(body: UpdateResponseBody | HistoryResponseBody | { success: false; error: string }, status: number): Response {
+interface ErrorResponseBody {
+	success: false;
+	error: string;
+	/** Present only when a batch failed after some records already changed. */
+	data?: {
+		updated: boolean;
+		records: RecordResult[];
+	};
+}
+
+function jsonResponse(body: UpdateResponseBody | HistoryResponseBody | ErrorResponseBody, status: number): Response {
 	return new Response(JSON.stringify(body), {
 		status,
 		headers: { 'Content-Type': 'application/json' },
@@ -289,6 +311,10 @@ function constructDNSRecords(request: Request): UpdateRequest {
 	if (overlong !== undefined) {
 		throw new HttpError(422, `Hostname exceeds ${String(HOSTNAME_MAX_LENGTH)} characters: '${overlong.slice(0, 60)}...'`);
 	}
+	const malformed = hostnames.find((hostname) => !HOSTNAME_PATTERN.test(hostname));
+	if (malformed !== undefined) {
+		throw new HttpError(422, `Not a valid hostname: '${encodeURIComponent(malformed)}'`);
+	}
 
 	// Per hostname: an A record when ip4 resolved, an AAAA when ip6 did.
 	const records: DDNSRecord[] = [];
@@ -337,8 +363,10 @@ async function writeCachedIp(env: Env, tokenId: string, record: DDNSRecord): Pro
 }
 
 // A worker invocation is wall-clock bound, so the SDK defaults (60s per
-// request, 2 retries) would let one stalled call spend the whole budget.
-const API_TIMEOUT_MS = 10_000;
+// request, 2 retries) would let one stalled call spend the whole budget. A
+// batch waits for every record to settle before responding, so this ceiling
+// is also what bounds how long one slow record holds the whole response.
+const API_TIMEOUT_MS = 5_000;
 const API_MAX_RETRIES = 1;
 
 function apiClient(auth: ParsedAuth): Cloudflare {
@@ -446,10 +474,12 @@ function zonesHosting(zones: CachedZone[], hostname: string): CachedZone[] {
 
 /**
  * Looks up, compares, and (when the DNS content differs) updates one record.
- * Zone lookups run in parallel. Throws HttpError on no/ambiguous matches;
- * with records processed concurrently, sibling records may already have
- * updated when one throws (same partial-application semantics as the old
- * sequential loop, which aborted mid-way).
+ * Zone lookups run in parallel. Throws HttpError on no or ambiguous matches.
+ *
+ * A batch applies partially: records are processed concurrently, so a throw
+ * here leaves siblings already updated. The caller audits and notifies for
+ * those before surfacing the failure, so a refused request never hides a
+ * change that reached DNS.
  */
 async function processRecord(
 	cloudflare: Cloudflare,
@@ -607,14 +637,14 @@ async function updateHostnames(
 
 	const callerIp = request.headers.get('CF-Connecting-IP');
 	const visibleZones = zones;
-	const processed = await Promise.all(
+	// Settled, not all: records are processed concurrently, so one failure
+	// leaves siblings that already changed DNS. Those changes are real and
+	// have to reach the audit trail and the notification whether or not the
+	// request as a whole ends up refused.
+	const settled = await Promise.allSettled(
 		pending.map(async (record) => processRecord(cloudflare, env, visibleZones, record, callerIp, tokenId)),
 	);
-	const processedByRecord = new Map(processed.map((p) => [p.record, p]));
-
-	const results: RecordResult[] = records.map(
-		(record) => processedByRecord.get(record)?.result ?? { hostname: record.name, type: record.type, ip: record.content, updated: false },
-	);
+	const processed = settled.filter((outcome) => outcome.status === 'fulfilled').map((outcome) => outcome.value);
 	const updateMessages = processed.map((p) => p.message).filter((m): m is string => m !== null);
 
 	// Audit writes and the change notification ride after the response;
@@ -627,6 +657,29 @@ async function updateHostnames(
 	);
 	if (updateMessages.length > 0) {
 		ctx.waitUntil(pushNtfy(updateMessages, ntfyUrl));
+	}
+
+	const processedByRecord = new Map(processed.map((p) => [p.record, p]));
+	const results: RecordResult[] = records.map(
+		(record) => processedByRecord.get(record)?.result ?? { hostname: record.name, type: record.type, ip: record.content, updated: false },
+	);
+
+	// Only once what landed is recorded and reportable does a failure decide
+	// the response.
+	const rejected = settled.filter((outcome) => outcome.status === 'rejected').map((outcome) => outcome.reason as unknown);
+	for (const reason of rejected) {
+		console.error('Record update failed:', reason);
+	}
+	if (rejected.length > 0) {
+		// An HttpError names what the caller must fix. Taking the first by
+		// index instead would let a transient 500 on an early record mask it,
+		// and 5xx is the status a DDNS client retries against.
+		const actionable = rejected.find((reason) => reason instanceof HttpError);
+		const applied = results.filter((result) => result.updated);
+		if (actionable !== undefined) {
+			throw new HttpError(actionable.statusCode, actionable.message, applied);
+		}
+		throw new HttpError(500, 'Internal Server Error', applied);
 	}
 
 	const anyUpdated = updateMessages.length > 0;
@@ -696,7 +749,13 @@ export default {
 			const isHttpError = err instanceof HttpError;
 			const message = isHttpError ? err.message : 'Internal Server Error';
 			const statusCode = isHttpError ? err.statusCode : 500;
+			const applied = isHttpError ? err.applied : [];
 			console.error(`Error handling request: ${message}`, err);
+			// A partly-applied batch reports what changed, so the caller does
+			// not read the error as "nothing happened".
+			if (applied.length > 0) {
+				return jsonResponse({ success: false, error: message, data: { updated: true, records: applied } }, statusCode);
+			}
 			return jsonResponse({ success: false, error: message }, statusCode);
 		}
 	},

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -772,6 +772,48 @@ describe('Worker fetch handler', () => {
 			expect(mockCloudflareClient.dns.records.update).toHaveBeenCalledTimes(1);
 		});
 
+		// Query parameters arrive percent-decoded, so an unchecked hostname
+		// carries whatever the caller encoded into the log lines that quote it.
+		it.each([
+			['an embedded newline', 'a%0AFAKE-LOG-LINE'],
+			['a space', 'has%20space.example.com'],
+			['a leading dot', '.example.com'],
+			['a mid-label wildcard', 'a.*.example.com'],
+			['an underscore', 'under_score.example.com'],
+		])('rejects a hostname with %s', async (_label, encoded) => {
+			const request = createMockRequest(`https://example.com/update?ip4=1.2.3.4&hostnames=${encoded}`, {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+
+			expect(response.status).toBe(422);
+			const body = (await response.json()) as any;
+			expect(body.error).toContain('Not a valid hostname');
+			// The echoed name is re-encoded, so a newline cannot break the line.
+			expect(body.error).not.toContain('\n');
+		});
+
+		it.each([
+			['a plain fqdn', 'test.example.com'],
+			['a wildcard', '*.example.com'],
+			['a zone apex', 'example.com'],
+			['a punycode idn', 'xn--bcher-kva.example.com'],
+			['a hyphenated label', 'my-host-1.example.com'],
+		])('accepts %s', async (_label, hostname) => {
+			mockCloudflareClient.zones.list.mockReturnValue(mockPage({ result: [] }));
+
+			const request = createMockRequest(`https://example.com/update?ip4=1.2.3.4&hostnames=${encodeURIComponent(hostname)}`, {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+			const body = (await response.json()) as any;
+
+			// Refused later for having no zones, never for its shape.
+			expect(body.error).not.toContain('Not a valid hostname');
+		});
+
 		it('rejects a hostname longer than a DNS name may be', async () => {
 			// An over-long name also pushes the KV cache key past its own limit.
 			const hostname = `${'a'.repeat(250)}.example.com`;
@@ -2218,6 +2260,153 @@ describe('Worker fetch handler', () => {
 			await worker.fetch(request, env, ctx);
 
 			expect(waitUntilMock).not.toHaveBeenCalled();
+		});
+
+		it('audits and notifies the records that landed even when a sibling record fails', async () => {
+			// Records are processed concurrently, so a refusal on one arrives
+			// after another has already changed DNS. That change is real and must
+			// not vanish from the audit trail because the response is an error.
+			const { pushNtfy } = await import('../src/pushNtfy');
+			const pushNtfyMock = vi.mocked(pushNtfy);
+			mockCloudflareClient.zones.list.mockReturnValue(mockPage({ result: [{ id: 'zone1', name: 'example.com' }] }));
+			// good.example.com resolves and changes; missing.example.com does not exist.
+			mockCloudflareClient.dns.records.list.mockImplementation((params: any) =>
+				params.name.exact === 'good.example.com'
+					? mockPage({ result: [{ id: 'r1', name: 'good.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }] })
+					: mockPage({ result: [] }),
+			);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=good.example.com,missing.example.com', {
+				headers: { ...validAuth, 'CF-Connecting-IP': '5.6.7.8' },
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+
+			// The request is still refused: one hostname could not be updated.
+			expect(response.status).toBe(400);
+			const body = (await response.json()) as any;
+			expect(body.error).toContain("No matching record found for 'missing.example.com'");
+
+			// The DNS change that did land was applied, so it must be recorded.
+			expect(mockCloudflareClient.dns.records.update).toHaveBeenCalledWith('r1', expect.objectContaining({ content: '1.2.3.4' }));
+
+			const waitUntilArgs = (waitUntilMock.mock.calls as [Promise<void>][]).map(([p]) => p);
+			await Promise.allSettled(waitUntilArgs);
+
+			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
+			expect(auditDbMock.batch).toHaveBeenCalledTimes(1);
+			const [batchArg] = auditDbMock.batch.mock.calls[0] as [unknown[]];
+			expect(batchArg).toHaveLength(1);
+			expect(auditDbMock.prepare().bind).toHaveBeenCalledWith(
+				expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+				'token-id-123',
+				'5.6.7.8',
+				'good.example.com',
+				'A',
+				'1.2.3.0',
+				'1.2.3.4',
+				'updated',
+			);
+			expect(pushNtfyMock).toHaveBeenCalledWith([expect.stringContaining('good.example.com')], null);
+		});
+
+		it('reports the records that landed in the error body', async () => {
+			// A caller that reads only the status would otherwise conclude
+			// nothing changed while its sibling record was repointed.
+			mockCloudflareClient.zones.list.mockReturnValue(mockPage({ result: [{ id: 'zone1', name: 'example.com' }] }));
+			mockCloudflareClient.dns.records.list.mockImplementation((params: any) =>
+				params.name.exact === 'good.example.com'
+					? mockPage({ result: [{ id: 'r1', name: 'good.example.com', type: 'A', content: '1.2.3.0', proxied: false, ttl: 1 }] })
+					: mockPage({ result: [] }),
+			);
+			mockCloudflareClient.dns.records.update.mockResolvedValue(undefined);
+
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=good.example.com,missing.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+			const body = (await response.json()) as any;
+
+			expect(response.status).toBe(400);
+			expect(body.success).toBe(false);
+			expect(body.data).toEqual({
+				updated: true,
+				records: [{ hostname: 'good.example.com', type: 'A', ip: '1.2.3.4', updated: true }],
+			});
+		});
+
+		it('surfaces the actionable refusal rather than a transient failure on an earlier record', async () => {
+			// find() scans by index, so an early transport error would mask a
+			// later 400. A 5xx is also what a DDNS client retries against, so
+			// the caller would loop on a permanent misconfiguration.
+			mockCloudflareClient.zones.list.mockReturnValue(mockPage({ result: [{ id: 'zone1', name: 'example.com' }] }));
+			mockCloudflareClient.dns.records.list.mockImplementation((params: any) => {
+				if (params.name.exact === 'aaa.example.com') {
+					return { then: (_r: any, reject: any) => reject(new MockInternalServerError()) };
+				}
+				return mockPage({ result: [] });
+			});
+
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=aaa.example.com,zzz.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+			const body = (await response.json()) as any;
+
+			expect(response.status).toBe(400);
+			expect(body.error).toContain("No matching record found for 'zzz.example.com'");
+		});
+
+		it('returns 500 when every failure is a transport error', async () => {
+			mockCloudflareClient.zones.list.mockReturnValue(mockPage({ result: [{ id: 'zone1', name: 'example.com' }] }));
+			mockCloudflareClient.dns.records.list.mockImplementation(() => ({
+				then: (_r: any, reject: any) => reject(new MockInternalServerError()),
+			}));
+
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=a.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+			const body = (await response.json()) as any;
+
+			expect(response.status).toBe(500);
+			expect(body).toEqual({ success: false, error: 'Internal Server Error' });
+		});
+
+		it('logs every failure in a batch, not only the one it reports', async () => {
+			const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+			mockCloudflareClient.zones.list.mockReturnValue(mockPage({ result: [{ id: 'zone1', name: 'example.com' }] }));
+			mockCloudflareClient.dns.records.list.mockReturnValue(mockPage({ result: [] }));
+
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=a.example.com,b.example.com,c.example.com', {
+				headers: validAuth,
+			});
+
+			await worker.fetch(request, env, ctx);
+
+			const failureLogs = errorSpy.mock.calls.filter(([msg]) => msg === 'Record update failed:');
+			expect(failureLogs).toHaveLength(3);
+		});
+
+		it('writes no audit batch when every record in the request fails', async () => {
+			mockCloudflareClient.zones.list.mockReturnValue(mockPage({ result: [{ id: 'zone1', name: 'example.com' }] }));
+			mockCloudflareClient.dns.records.list.mockReturnValue(mockPage({ result: [] }));
+
+			const request = createMockRequest('https://example.com/update?ip4=1.2.3.4&hostnames=a.example.com,b.example.com', {
+				headers: validAuth,
+			});
+
+			const response = await worker.fetch(request, env, ctx);
+
+			expect(response.status).toBe(400);
+			const waitUntilArgs = (waitUntilMock.mock.calls as [Promise<void>][]).map(([p]) => p);
+			await Promise.allSettled(waitUntilArgs);
+			// Nothing reached DNS, so there is nothing to audit.
+			expect((vi.mocked(env.AUDIT_DB) as any).batch).not.toHaveBeenCalled();
 		});
 
 		it('passes one correctly-shaped audit event to AUDIT_DB.batch per record that reached DNS', async () => {


### PR DESCRIPTION
Closes the last item carried over from #182 and #183.

## The gap

Records are processed concurrently, so a refusal on one arrives *after* siblings have already changed DNS. `Promise.all` rejected on the first failure, and `writeAuditEvents` sat on the success path, so those DNS changes happened and left no audit row. The trail silently disagreed with reality exactly when it mattered.

Measured before the fix: 20 hostnames with one bad name produced **19 DNS updates and 0 audit rows**.

Settling every record first means the audit write and the ntfy notification cover what landed; only then does the failure decide the response.

## Three things that fell out of the review

**The caller was still told nothing.** A bare 400 reads as "nothing happened" while 19 records moved. An error response now carries what changed:

```json
{
  "success": false,
  "error": "No matching record found for 'missing.example.com'. Create it manually first.",
  "data": { "updated": true, "records": [{ "hostname": "good.example.com", "type": "A", "ip": "1.2.3.4", "updated": true }] }
}
```

Additive: clients that ignore `data` are unaffected.

**Picking the failure by index was wrong.** `settled.find(...)` scans by position, so a transient `InternalServerError` on an early record deterministically masked a later `HttpError`. Two costs: the caller loses the message that would fix it, and 5xx is what DDNS clients retry aggressively while 4xx is treated as permanent, so a config error became a retry loop against the rate limit. An `HttpError` now wins over a transport error.

**Losing rejections vanished.** Five simultaneous failures produced one logged line and four silent drops. Every rejection is logged now.

## Costs, stated plainly

Waiting for all records to settle means the **slowest** record bounds the failure response, not the first refusal. Measured: one instant refusal alongside a 1200ms sibling went from 2ms to 1215ms. That is inherent to the guarantee, since you cannot audit what landed without waiting for it to land. `API_TIMEOUT_MS` drops from 10s to 5s to cap what one stalled record can hold.

Worth noting the old behaviour was not free either: `Promise.all` returned while sibling updates were still in flight and unawaited, so those could be cut off mid-request. Settling is more correct on that count too.

## Also

Hostnames are validated against a DNS name shape. Query parameters arrive percent-decoded, so `%0A` inside a hostname reached the log lines that quote it, letting a tenant forge entries in the operator's Workers Logs. The echoed name in the 422 is re-encoded.

## Verification

172 tests at 100% coverage, deploy dry run builds. Both the audit-gap case and the error-selection case were confirmed to fail against the pre-fix code before passing against it.

## Deliberately not here

Refused records still produce no audit row at all. "Token X was refused on hostname Y" is arguably what the trail exists for, but `outcome` carries a `CHECK (outcome IN ('updated', 'no-change'))` constraint, so adding it needs a D1 migration against production. Worth doing as its own change.