### PR TITLE
feat(history): paginate the audit trail past the first thousand rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ curl -H "Authorization: Bearer <api-token>" -H "X-Access-Key: <access-key-if-set
 
 Cache fast-path hits are not recorded; only requests that reached the DNS API produce events.
 
+Pages are capped at 1000 events. The response carries `data.cursor`, and passing it back as `before=`
+continues from where the page ended; it is `null` on the last page. Treat the value as opaque and pass it
+verbatim, and keep `hostname=` fixed across a walk, since the cursor is a position in the result set the
+page came from. `data.refusedToday` below rides on the first page only, since it describes the day rather
+than the page.
+
+The cursor embeds the audit row's id, which is a table-wide sequence. On a deployment several people share,
+that lets one of them read the total number of audit rows written before their own, and polling it times
+the others' activity. It is aggregate volume, never row contents, and a deployment serving one household
+leaks nothing to itself. Signing the cursor would close it, and that needs a deployment secret this worker
+does not require: `ACCESS_KEY` is optional, and the deployments that leave it unset are the shared ones
+where this matters.
+
 The response also carries `data.refusedToday`: the times this token reached past its own authority today,
 UTC, and the names it reached for.
 
@@ -118,7 +131,8 @@ Reaching past authority means a hostname no zone on the token could hold, or a `
 cannot see. A record you have not created yet is **not** counted, nor is a token missing the Zone Read
 scope, nor is a token that sees no zones at all: those are setup steps, and counting them would bury the
 signal under every new user's first afternoon. The `hostnames` list is your own, so it names exactly which
-of your entries to fix.
+of your entries to fix. It carries 50 of them, the last to be seen for the first time, since a name refused
+again keeps its original place. `distinct` counts every name the tally kept, which itself stops at 200.
 
 Refusals are **counted, not recorded per event**. Any active Cloudflare token can produce them without
 limit, so a row apiece would let one caller grow a table every deployment shares. The tally lives in a

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -12,14 +12,83 @@ export interface AuditEvent {
 	outcome: 'updated' | 'no-change';
 }
 
+/**
+ * The sort key of the last row already returned, which the next page resumes at.
+ *
+ * A timestamp alone cannot resume the walk: a batch writes several rows in one
+ * millisecond, so a boundary can land inside a group sharing a timestamp, and a
+ * comparison would then either repeat that group or drop the rest of it. The
+ * row id is the only value that is unique and stable enough to settle it.
+ *
+ * That id is a table-wide sequence, so a caller can read the deployment's total
+ * audit volume off a cursor, and by polling can time other tenants' activity. On
+ * a deployment one household runs, it says nothing the caller does not own.
+ *
+ * Signing or encrypting the pair with a deployment secret would close the
+ * channel and keep the walk identical, and it is not done here because no such
+ * secret is guaranteed to exist: ACCESS_KEY is optional, and the deployments
+ * that leave it unset are exactly the shared ones where this would matter. The
+ * README states the caveat rather than the mechanism pretending it away.
+ */
+export interface HistoryCursor {
+	occurredAt: string;
+	id: number;
+}
+
 export interface HistoryQuery {
 	tokenId: string;
 	hostname: string | null;
 	limit: number;
+	before: HistoryCursor | null;
+}
+
+export interface HistoryPage {
+	events: Record<string, unknown>[];
+	/** Pass back as `before` to continue; null when this page is the last. */
+	cursor: string | null;
 }
 
 export const HISTORY_DEFAULT_LIMIT = 100;
 export const HISTORY_MAX_LIMIT = 1000;
+
+/** The exact shape `new Date().toISOString()` writes into `occurred_at`. */
+const OCCURRED_AT_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+/** Plain digits, short of the range where an integer stops being exact. */
+const ROW_ID_PATTERN = /^\d{1,15}$/;
+
+/**
+ * Reads a `before` value, or null when it is not one this module emitted.
+ *
+ * The wire form is `<occurred_at>|<id>`, which callers pass back verbatim. Both
+ * halves are matched against the shape the writer produces rather than coerced:
+ * `Number` alone accepts `0x10`, `1e3`, and a leading newline, so a value that
+ * never came from here would read as one that did.
+ */
+export function parseHistoryCursor(raw: string): HistoryCursor | null {
+	const separator = raw.lastIndexOf('|');
+	if (separator <= 0) {
+		return null;
+	}
+	const occurredAt = raw.slice(0, separator);
+	const id = raw.slice(separator + 1);
+	if (!OCCURRED_AT_PATTERN.test(occurredAt) || !isCanonicalTimestamp(occurredAt) || !ROW_ID_PATTERN.test(id)) {
+		return null;
+	}
+	return { occurredAt, id: Number(id) };
+}
+
+/**
+ * Whether the value is a date and not merely shaped like one.
+ *
+ * The pattern admits `2026-99-99T99:99:99.999Z`, which sorts above every real
+ * row and would hand back the first page again. That is the restart the 422
+ * exists to prevent, reached through a value the pattern let through.
+ */
+function isCanonicalTimestamp(value: string): boolean {
+	const parsed = new Date(value);
+	return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
+}
 
 /** Appends audit events in one batch. Best-effort: an audit failure must
  * never fail the DNS update that already happened; it is logged instead. */
@@ -37,19 +106,53 @@ export async function writeAuditEvents(env: Env, events: AuditEvent[]): Promise<
 	}
 }
 
-/** Returns the caller's own audit rows, newest first. Tenant isolation is
- * the token ID: callers only ever see events created with their token. */
-export async function queryHistory(env: Env, query: HistoryQuery): Promise<Record<string, unknown>[]> {
-	const limit = Math.min(Math.max(Math.trunc(query.limit), 1), HISTORY_MAX_LIMIT);
-	const base = 'SELECT occurred_at, hostname, record_type, previous_ip, new_ip, outcome, caller_ip FROM audit_events WHERE token_id = ?';
-	const statement =
-		query.hostname !== null && query.hostname !== ''
-			? env.AUDIT_DB.prepare(`${base} AND hostname = ? ORDER BY occurred_at DESC, id DESC LIMIT ?`).bind(
-					query.tokenId,
-					query.hostname,
-					limit,
-				)
-			: env.AUDIT_DB.prepare(`${base} ORDER BY occurred_at DESC, id DESC LIMIT ?`).bind(query.tokenId, limit);
-	const { results } = await statement.all();
-	return results;
+/** Returns the caller's own audit rows, newest first, with the cursor that
+ * continues them. Tenant isolation is the token ID: callers only ever see
+ * events created with their token, and the cursor is applied inside that
+ * scope, so one cannot walk into another's rows. */
+export async function queryHistory(env: Env, query: HistoryQuery): Promise<HistoryPage> {
+	// Finite before clamped: Math.trunc(NaN) is NaN, and every comparison
+	// against it is false, so the clamp would pass it through to the bind and
+	// SQLite would reject the statement.
+	const requested = Number.isFinite(query.limit) ? query.limit : HISTORY_DEFAULT_LIMIT;
+	const limit = Math.min(Math.max(Math.trunc(requested), 1), HISTORY_MAX_LIMIT);
+	const filters = ['token_id = ?'];
+	const binds: (string | number)[] = [query.tokenId];
+	if (query.hostname !== null && query.hostname !== '') {
+		filters.push('hostname = ?');
+		binds.push(query.hostname);
+	}
+	if (query.before !== null) {
+		// Two predicates rather than one row-value comparison, because the sort
+		// mixes directions. The first is a plain range on the leading index
+		// column, which is what keeps a deep page costing the page rather than
+		// the history behind it; the second drops the rows of the boundary group
+		// that already went out.
+		filters.push('occurred_at <= ? AND (occurred_at < ? OR id > ?)');
+		binds.push(query.before.occurredAt, query.before.occurredAt, query.before.id);
+	}
+	// Ascending inside a group sharing a timestamp. An audit row is written
+	// after the response through waitUntil, so it can land well after the
+	// timestamp it carries; taking the highest id last means a row arriving into
+	// a group the walk is still crossing is picked up rather than sorted behind
+	// a cursor that already passed it.
+	const sql = `SELECT id, occurred_at, hostname, record_type, previous_ip, new_ip, outcome, caller_ip FROM audit_events WHERE ${filters.join(' AND ')} ORDER BY occurred_at DESC, id ASC LIMIT ?`;
+	// One row past the page, so a full page is told from a last page without a
+	// second query and without ever answering with an empty final page.
+	const { results } = await env.AUDIT_DB.prepare(sql)
+		.bind(...binds, limit + 1)
+		.all();
+	const page = results.slice(0, limit);
+	const last = page.at(-1);
+	const cursor = last === undefined || results.length <= limit ? null : `${String(last['occurred_at'])}|${String(last['id'])}`;
+	return {
+		// `id` orders the walk and is not something the caller asked for.
+		events: page.map(({ id: _id, ...event }) => event),
+		// Read back through the parser before it goes out. A row whose timestamp
+		// this module did not write, from a backfill or an operator insert, would
+		// otherwise produce a cursor the next request refuses, and the walk would
+		// die on a 422 blaming the caller for a value the server handed it. One
+		// page and no cursor is the honest answer instead.
+		cursor: cursor !== null && parseHistoryCursor(cursor) !== null ? cursor : null,
+	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
 	PermissionDeniedError,
 	RateLimitError,
 } from 'cloudflare';
-import { HISTORY_DEFAULT_LIMIT, queryHistory, writeAuditEvents, type AuditEvent } from './audit';
+import { HISTORY_DEFAULT_LIMIT, parseHistoryCursor, queryHistory, writeAuditEvents, type AuditEvent } from './audit';
 import { pushNtfy } from './pushNtfy';
 import type { RefusalTally } from './refusals';
 export { RefusalCounter } from './refusals';
@@ -149,10 +149,19 @@ async function countRefusals(env: Env, tokenId: string, hostnames: string[]): Pr
 	}
 }
 
+// Names carried in the tally a response reports. The counter keeps up to 200
+// of up to 253 characters each, which would put 50 KiB of them on a response
+// whose point is the audit rows. Taken from the end for the same reason as
+// ALERT_SAMPLE: the list is in the order names were first seen, so the head is
+// whatever the day opened with, and a caller who fixed those would keep reading
+// back the ones already fixed.
+const REFUSED_NAMES_REPORTED = -50;
+
 /** The caller's refusals for today; an unreadable counter reads as none. */
 async function readRefusalTally(env: Env, tokenId: string): Promise<RefusalTally> {
 	try {
-		return await env.REFUSALS.getByName(tokenId).tally(currentDay());
+		const tally = await env.REFUSALS.getByName(tokenId).tally(currentDay());
+		return { ...tally, hostnames: tally.hostnames.slice(REFUSED_NAMES_REPORTED) };
 	} catch (error) {
 		console.error(`Failed to read the refusal tally for token ${tokenId}:`, error);
 		return { total: 0, distinct: 0, hostnames: [] };
@@ -307,8 +316,10 @@ interface HistoryResponseBody {
 	success: boolean;
 	data: {
 		events: Record<string, unknown>[];
-		/** Refusals counted against this token today, UTC. */
-		refusedToday: RefusalTally;
+		/** Pass back as `before` to continue; null when this page is the last. */
+		cursor: string | null;
+		/** Refusals counted against this token today, UTC. Only on the first page. */
+		refusedToday: RefusalTally | null;
 	};
 }
 
@@ -1073,16 +1084,38 @@ async function updateHostnames(
 
 /** GET /history: the caller's own audit rows, newest first. */
 async function handleHistory(auth: ParsedAuth, request: Request, env: Env): Promise<Response> {
+	// Every parameter is checked before the token is verified, so a request that
+	// cannot be answered whatever the token says never spends a Cloudflare API
+	// call, matching how the access key gates the update path.
+	const { searchParams } = new URL(request.url);
+	const hostname = searchParams.get('hostname')?.trim() ?? null;
+	if (hostname !== null && hostname !== '' && (hostname.length > HOSTNAME_MAX_LENGTH || !HOSTNAME_PATTERN.test(hostname))) {
+		// The same shape /update enforces. Without it a typo answers with an
+		// empty page, which reads as "nothing ever happened to that name".
+		throw new HttpError(422, `Not a valid hostname: '${quoteInput(hostname)}'`);
+	}
+	const limitParam = Number(searchParams.get('limit') ?? HISTORY_DEFAULT_LIMIT);
+	const limit = Number.isFinite(limitParam) ? limitParam : HISTORY_DEFAULT_LIMIT;
+	const rawCursor = searchParams.get('before')?.trim() ?? '';
+	const before = rawCursor === '' ? null : parseHistoryCursor(rawCursor);
+	if (before === null && rawCursor !== '') {
+		// Rejected rather than ignored. Ignoring it would answer with the first
+		// page, and a client walking pages would read that as a fresh start and
+		// loop over the same rows forever.
+		throw new HttpError(422, "The 'before' parameter must be a cursor from a previous response.");
+	}
+
 	const cloudflare = apiClient(auth);
 	const tokenId = await verifyToken(cloudflare);
 
-	const { searchParams } = new URL(request.url);
-	const hostname = searchParams.get('hostname')?.trim() ?? null;
-	const limitParam = Number(searchParams.get('limit') ?? HISTORY_DEFAULT_LIMIT);
-	const limit = Number.isFinite(limitParam) ? limitParam : HISTORY_DEFAULT_LIMIT;
-
-	const [events, refusedToday] = await Promise.all([queryHistory(env, { tokenId, hostname, limit }), readRefusalTally(env, tokenId)]);
-	return jsonResponse({ success: true, data: { events, refusedToday } }, 200);
+	// The tally rides on the first page only. It describes the day rather than
+	// the page, so repeating it down a walk would spend one Durable Object round
+	// trip per page to say the same thing.
+	const [page, refusedToday] = await Promise.all([
+		queryHistory(env, { tokenId, hostname, limit, before }),
+		before === null ? readRefusalTally(env, tokenId) : null,
+	]);
+	return jsonResponse({ success: true, data: { events: page.events, cursor: page.cursor, refusedToday } }, 200);
 }
 
 export default {

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { writeAuditEvents, queryHistory, type AuditEvent } from '../src/audit';
+import { writeAuditEvents, queryHistory, parseHistoryCursor, type AuditEvent } from '../src/audit';
 import { createMockEnv } from './helpers/mocks';
 
 describe('writeAuditEvents', () => {
@@ -172,25 +172,28 @@ describe('queryHistory', () => {
 	// -------------------------------------------------------------------------
 
 	describe('base query without hostname filter', () => {
-		it('returns the rows from AUDIT_DB', async () => {
+		it('returns the rows from AUDIT_DB without the cursor field', async () => {
 			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
 			const stmtMock = auditDbMock.prepare();
-			const fakeRows = [{ hostname: 'test.example.com', outcome: 'updated' }];
-			stmtMock.all.mockResolvedValue({ results: fakeRows });
+			stmtMock.all.mockResolvedValue({ results: [{ id: 7, hostname: 'test.example.com', outcome: 'updated' }] });
 
-			const results = await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 100 });
+			const page = await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 100, before: null });
 
-			expect(results).toEqual(fakeRows);
+			// `id` exists to order and resume the walk. It is not something the
+			// caller asked for, and it counts rows every tenant wrote.
+			expect(page.events).toEqual([{ hostname: 'test.example.com', outcome: 'updated' }]);
 		});
 
-		it('binds token_id and limit when no hostname filter is set', async () => {
+		it('binds token_id and one row past the limit when no hostname filter is set', async () => {
 			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
 			const stmtMock = auditDbMock.prepare();
 			stmtMock.all.mockResolvedValue({ results: [] });
 
-			await queryHistory(env, { tokenId: 'token-id-123', hostname: null, limit: 50 });
+			await queryHistory(env, { tokenId: 'token-id-123', hostname: null, limit: 50, before: null });
 
-			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 50);
+			// One past, so a full page is told from a last page without a second
+			// query and without ever answering with an empty final page.
+			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 51);
 		});
 	});
 
@@ -199,14 +202,14 @@ describe('queryHistory', () => {
 	// -------------------------------------------------------------------------
 
 	describe('hostname filter', () => {
-		it('binds token_id, hostname, and limit when hostname is provided', async () => {
+		it('binds token_id, hostname, and the limit when hostname is provided', async () => {
 			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
 			const stmtMock = auditDbMock.prepare();
 			stmtMock.all.mockResolvedValue({ results: [] });
 
-			await queryHistory(env, { tokenId: 'token-id-123', hostname: 'test.example.com', limit: 100 });
+			await queryHistory(env, { tokenId: 'token-id-123', hostname: 'test.example.com', limit: 100, before: null });
 
-			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 'test.example.com', 100);
+			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 'test.example.com', 101);
 		});
 
 		it('uses the unfiltered query when hostname is an empty string', async () => {
@@ -214,10 +217,156 @@ describe('queryHistory', () => {
 			const stmtMock = auditDbMock.prepare();
 			stmtMock.all.mockResolvedValue({ results: [] });
 
-			await queryHistory(env, { tokenId: 'tid', hostname: '', limit: 100 });
+			await queryHistory(env, { tokenId: 'tid', hostname: '', limit: 100, before: null });
 
 			// Empty string is treated as no filter: only two args bound
-			expect(stmtMock.bind).toHaveBeenCalledWith('tid', 100);
+			expect(stmtMock.bind).toHaveBeenCalledWith('tid', 101);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Pagination
+	// -------------------------------------------------------------------------
+
+	describe('pagination', () => {
+		const rows = (count: number, at?: string): Record<string, unknown>[] =>
+			Array.from({ length: count }, (_unused, i) => ({
+				id: i + 1,
+				occurred_at: at ?? `2026-08-06T00:00:00.00${String(i)}Z`,
+				hostname: 'a.example.com',
+			}));
+
+		it('reports no cursor when the page is the last', async () => {
+			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
+			const stmtMock = auditDbMock.prepare();
+			stmtMock.all.mockResolvedValue({ results: rows(2) });
+
+			const page = await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 2, before: null });
+
+			expect(page.cursor).toBeNull();
+			expect(page.events).toHaveLength(2);
+		});
+
+		it('reports no cursor when there are no rows at all', async () => {
+			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
+			const stmtMock = auditDbMock.prepare();
+			stmtMock.all.mockResolvedValue({ results: [] });
+
+			const page = await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 2, before: null });
+
+			expect(page.cursor).toBeNull();
+			expect(page.events).toEqual([]);
+		});
+
+		it('trims the extra row and reports the last row it returned', async () => {
+			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
+			const stmtMock = auditDbMock.prepare();
+			stmtMock.all.mockResolvedValue({ results: rows(3) });
+
+			const page = await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 2, before: null });
+
+			// The row past the limit is what proves more exist; it is not returned,
+			// and the cursor names the last row that was.
+			expect(page.events).toHaveLength(2);
+			expect(page.cursor).toBe('2026-08-06T00:00:00.001Z|2');
+		});
+
+		it('resumes inside a group rather than excluding the whole group', async () => {
+			// A batch writes several rows in one millisecond, so a page boundary
+			// can land inside a group. Excluding the timestamp would drop the rest
+			// of that group; including it without the id would repeat it.
+			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
+			const stmtMock = auditDbMock.prepare();
+			stmtMock.all.mockResolvedValue({ results: [] });
+
+			await queryHistory(env, {
+				tokenId: 'tid',
+				hostname: null,
+				limit: 10,
+				before: { occurredAt: '2026-08-06T00:00:01.000Z', id: 2 },
+			});
+
+			expect(stmtMock.bind).toHaveBeenCalledWith('tid', '2026-08-06T00:00:01.000Z', '2026-08-06T00:00:01.000Z', 2, 11);
+		});
+
+		it('orders a shared timestamp ascending so a late write is not sorted behind the cursor', async () => {
+			// An audit row is written after the response through waitUntil, so it
+			// can land well after the timestamp it carries. Taking the highest id
+			// last means a row arriving into a group the walk is still crossing is
+			// picked up rather than skipped.
+			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
+			auditDbMock.prepare().all.mockResolvedValue({ results: [] });
+
+			await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 10, before: null });
+
+			expect(auditDbMock.prepare.mock.calls.at(-1)?.[0]).toContain('ORDER BY occurred_at DESC, id ASC');
+		});
+
+		it('withholds a cursor it could not read back', async () => {
+			// A row whose timestamp this module did not write, from a backfill or
+			// an operator insert, would otherwise produce a cursor the next
+			// request refuses, and the walk would die on a 422 blaming the caller
+			// for a value the server handed it.
+			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
+			auditDbMock.prepare().all.mockResolvedValue({
+				results: [
+					{ id: 1, occurred_at: '2026-08-06 00:00:00', hostname: 'a.example.com' },
+					{ id: 2, occurred_at: '2026-08-06 00:00:00', hostname: 'b.example.com' },
+				],
+			});
+
+			const page = await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 1, before: null });
+
+			expect(page.events).toHaveLength(1);
+			expect(page.cursor).toBeNull();
+		});
+
+		it('applies the cursor inside the tenant scope', async () => {
+			// A cursor is caller-supplied, so it must never be able to reach past
+			// the token filter into another tenant's rows.
+			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
+			auditDbMock.prepare().all.mockResolvedValue({ results: [] });
+
+			await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 10, before: { occurredAt: 'x', id: 1 } });
+
+			expect(auditDbMock.prepare.mock.calls.at(-1)?.[0]).toContain('token_id = ? AND occurred_at <= ? AND (occurred_at < ? OR id > ?)');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Cursor parsing
+	// -------------------------------------------------------------------------
+
+	describe('parseHistoryCursor', () => {
+		it('reads back a cursor this module emitted', () => {
+			expect(parseHistoryCursor('2026-08-06T00:00:01.000Z|42')).toEqual({ occurredAt: '2026-08-06T00:00:01.000Z', id: 42 });
+		});
+
+		it.each([
+			['no separator', '2026-08-06T00:00:01.000Z'],
+			['an empty timestamp', '|42'],
+			['a timestamp the writer cannot produce', 'not-a-timestamp|1'],
+			// Shaped like a date and not one. It sorts above every real row, so
+			// admitting it would hand back the first page and read as a restart.
+			['a month and day out of range', '2026-99-99T99:99:99.999Z|1'],
+			['a day that does not exist that month', '2026-02-30T00:00:00.000Z|1'],
+			['a timestamp without milliseconds', '2026-08-06T00:00:01Z|1'],
+			['a quoted timestamp', "x' OR 1=1--|1"],
+			['a non-numeric id', '2026-08-06T00:00:01.000Z|abc'],
+			['a fractional id', '2026-08-06T00:00:01.000Z|1.5'],
+			['a negative id', '2026-08-06T00:00:01.000Z|-1'],
+			// Number() takes all three; the pattern is what refuses them, so a
+			// value that never came from here cannot read as one that did.
+			['a hexadecimal id', '2026-08-06T00:00:01.000Z|0x10'],
+			['an exponent id', '2026-08-06T00:00:01.000Z|1e3'],
+			['a padded id', '2026-08-06T00:00:01.000Z| 7 '],
+			['an id past the exact integer range', '2026-08-06T00:00:01.000Z|9007199254740993'],
+		])('rejects a cursor with %s', (_label, raw) => {
+			expect(parseHistoryCursor(raw)).toBeNull();
+		});
+
+		it('rejects a value long enough to be a payload rather than a cursor', () => {
+			expect(parseHistoryCursor(`${'A'.repeat(20000)}|1`)).toBeNull();
 		});
 	});
 
@@ -226,44 +375,24 @@ describe('queryHistory', () => {
 	// -------------------------------------------------------------------------
 
 	describe('limit clamping', () => {
-		it('clamps limit to 1000 when the caller supplies a value above the maximum', async () => {
+		it.each([
+			['clamps to the maximum when the caller supplies a value above it', 5000, 1001],
+			['clamps to one when the caller supplies zero', 0, 2],
+			['clamps to one when the caller supplies a negative value', -10, 2],
+			['passes through a value within the valid range unchanged', 42, 43],
+			// The module holds its own boundary rather than trusting its one
+			// caller: Math.trunc(NaN) is NaN, every comparison against it is
+			// false, and the clamp would hand NaN to the bind for SQLite to
+			// reject as a type mismatch.
+			['falls back to the default when the value is not a number', Number.NaN, 101],
+		])('%s', async (_label, limit, bound) => {
 			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
 			const stmtMock = auditDbMock.prepare();
 			stmtMock.all.mockResolvedValue({ results: [] });
 
-			await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 5000 });
+			await queryHistory(env, { tokenId: 'tid', hostname: null, limit, before: null });
 
-			expect(stmtMock.bind).toHaveBeenCalledWith('tid', 1000);
-		});
-
-		it('clamps limit to 1 when the caller supplies zero', async () => {
-			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
-			const stmtMock = auditDbMock.prepare();
-			stmtMock.all.mockResolvedValue({ results: [] });
-
-			await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 0 });
-
-			expect(stmtMock.bind).toHaveBeenCalledWith('tid', 1);
-		});
-
-		it('clamps limit to 1 when the caller supplies a negative value', async () => {
-			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
-			const stmtMock = auditDbMock.prepare();
-			stmtMock.all.mockResolvedValue({ results: [] });
-
-			await queryHistory(env, { tokenId: 'tid', hostname: null, limit: -10 });
-
-			expect(stmtMock.bind).toHaveBeenCalledWith('tid', 1);
-		});
-
-		it('passes through a value within the valid range unchanged', async () => {
-			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
-			const stmtMock = auditDbMock.prepare();
-			stmtMock.all.mockResolvedValue({ results: [] });
-
-			await queryHistory(env, { tokenId: 'tid', hostname: null, limit: 42 });
-
-			expect(stmtMock.bind).toHaveBeenCalledWith('tid', 42);
+			expect(stmtMock.bind).toHaveBeenCalledWith('tid', bound);
 		});
 	});
 });

--- a/tests/history-walk.test.ts
+++ b/tests/history-walk.test.ts
@@ -1,0 +1,131 @@
+import { env } from 'cloudflare:workers';
+import { applyD1Migrations, type D1Migration } from 'cloudflare:test';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { parseHistoryCursor, queryHistory } from '../src/audit';
+
+/**
+ * The paging contract, run against a real D1 built from the real migration.
+ *
+ * The rest of the audit suite mocks D1, which can only assert the shape of the
+ * SQL that goes out. What this change exists to deliver is a walk that returns
+ * every row exactly once across page boundaries that land inside a group of
+ * rows sharing a timestamp, and no mock can answer whether that holds.
+ */
+// The test pool supplies this from the vitest config rather than
+// wrangler.jsonc, so the generated Env cannot know about it.
+const testMigrations = (env as unknown as { TEST_MIGRATIONS: D1Migration[] }).TEST_MIGRATIONS;
+
+const OWNER = 'token-owner';
+const STRANGER = 'token-stranger';
+
+const stamp = (second: number, ms = 0): string =>
+	`2027-03-04T09:${String(Math.floor(second / 60)).padStart(2, '0')}:${String(second % 60).padStart(2, '0')}.${String(ms).padStart(3, '0')}Z`;
+
+const insert = async (occurredAt: string, tokenId: string, hostname: string): Promise<void> => {
+	await env.AUDIT_DB.prepare(
+		'INSERT INTO audit_events (occurred_at, token_id, caller_ip, hostname, record_type, previous_ip, new_ip, outcome) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+	)
+		.bind(occurredAt, tokenId, '203.0.113.7', hostname, 'A', '1.2.3.4', '1.2.3.5', 'updated')
+		.run();
+};
+
+/** Every hostname the walk returns, in order, following the cursor to the end. */
+const walk = async (limit: number, hostname: string | null = null): Promise<string[]> => {
+	const seen: string[] = [];
+	let before = null as ReturnType<typeof parseHistoryCursor>;
+	for (let page = 0; page < 500; page++) {
+		const result = await queryHistory(env, { tokenId: OWNER, hostname, limit, before });
+		seen.push(...result.events.map((event) => String(event['hostname'])));
+		if (result.cursor === null) {
+			return seen;
+		}
+		before = parseHistoryCursor(result.cursor);
+		// A cursor the emitter produced and the parser refuses would strand the
+		// walk on a 422 blaming the caller for a value the server handed it.
+		expect(before).not.toBeNull();
+	}
+	throw new Error('the walk did not reach a last page');
+};
+
+describe('history pagination against a real D1', () => {
+	beforeAll(async () => {
+		await applyD1Migrations(env.AUDIT_DB, testMigrations);
+	});
+
+	beforeEach(async () => {
+		await env.AUDIT_DB.prepare('DELETE FROM audit_events').run();
+	});
+
+	it('returns every row exactly once when a page boundary lands inside a shared timestamp', async () => {
+		// A batch writes one row per record in the same millisecond, so a group
+		// larger than a page is the ordinary case, not a contrived one.
+		await insert(stamp(3), OWNER, 'newest.example.com');
+		for (let i = 0; i < 25; i++) {
+			await insert(stamp(2), OWNER, `tie-${String(i).padStart(2, '0')}.example.com`);
+		}
+		await insert(stamp(1), OWNER, 'oldest.example.com');
+		const whole = await walk(100);
+
+		for (const limit of [1, 2, 7, 26]) {
+			const paged = await walk(limit);
+
+			expect(paged).toEqual(whole);
+			expect(new Set(paged).size).toBe(27);
+		}
+	});
+
+	it('never returns another token rows, whatever the cursor says', async () => {
+		await insert(stamp(2), OWNER, 'mine.example.com');
+		await insert(stamp(2), STRANGER, 'theirs.example.com');
+		await insert(stamp(1), OWNER, 'mine-older.example.com');
+
+		const paged = await walk(1);
+
+		expect(paged).toEqual(['mine.example.com', 'mine-older.example.com']);
+	});
+
+	it('picks up a row written into a group the walk is still crossing', async () => {
+		// Audit rows ride ctx.waitUntil, so one can land in D1 well after the
+		// timestamp it carries. Ordering a shared timestamp by ascending id puts
+		// the late arrival after the cursor rather than behind it.
+		for (let i = 0; i < 4; i++) {
+			await insert(stamp(2), OWNER, `batch-${String(i)}.example.com`);
+		}
+		await insert(stamp(1), OWNER, 'older.example.com');
+
+		const first = await queryHistory(env, { tokenId: OWNER, hostname: null, limit: 2, before: null });
+		await insert(stamp(2), OWNER, 'late.example.com');
+		const seen = first.events.map((event) => String(event['hostname']));
+		let before = parseHistoryCursor(first.cursor ?? '');
+		while (before !== null) {
+			const next = await queryHistory(env, { tokenId: OWNER, hostname: null, limit: 2, before });
+			seen.push(...next.events.map((event) => String(event['hostname'])));
+			before = next.cursor === null ? null : parseHistoryCursor(next.cursor);
+		}
+
+		expect(seen).toContain('late.example.com');
+		expect(new Set(seen).size).toBe(seen.length);
+	});
+
+	it('walks a hostname-filtered history the same way', async () => {
+		for (let i = 0; i < 6; i++) {
+			await insert(stamp(2), OWNER, i % 2 === 0 ? 'wanted.example.com' : 'other.example.com');
+		}
+
+		const paged = await walk(2, 'wanted.example.com');
+
+		expect(paged).toEqual(['wanted.example.com', 'wanted.example.com', 'wanted.example.com']);
+	});
+
+	it('reports no cursor when the last page is exactly full', async () => {
+		// The off-by-one that would hand back an empty final page and a cursor
+		// pointing at nothing.
+		await insert(stamp(2), OWNER, 'a.example.com');
+		await insert(stamp(1), OWNER, 'b.example.com');
+
+		const result = await queryHistory(env, { tokenId: OWNER, hostname: null, limit: 2, before: null });
+
+		expect(result.events).toHaveLength(2);
+		expect(result.cursor).toBeNull();
+	});
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -3354,6 +3354,89 @@ describe('Worker fetch handler', () => {
 			expect(Number.isInteger(bindArgs.at(-1))).toBe(true);
 		});
 
+		it('carries the cursor and the tally on the first page', async () => {
+			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
+			auditDbMock.prepare().all.mockResolvedValue({
+				results: Array.from({ length: 3 }, (_unused, i) => ({ id: i + 1, occurred_at: `2026-08-06T00:00:00.00${String(i)}Z` })),
+			});
+
+			const request = createMockRequest('https://example.com/history?limit=2', { headers: validAuth });
+			const body = (await (await worker.fetch(request, env, ctx)).json()) as any;
+
+			expect(body.data.cursor).toBe('2026-08-06T00:00:00.001Z|2');
+			expect(body.data.refusedToday).toEqual({ total: 0, distinct: 0, hostnames: [] });
+		});
+
+		it('omits the tally on a continuation page', async () => {
+			// The tally describes the day, not the page. Repeating it down a walk
+			// would spend one Durable Object round trip per page to say the same
+			// thing.
+			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
+			auditDbMock.prepare().all.mockResolvedValue({ results: [] });
+
+			const request = createMockRequest('https://example.com/history?before=2026-08-06T00%3A00%3A01.000Z%7C2', { headers: validAuth });
+			const body = (await (await worker.fetch(request, env, ctx)).json()) as any;
+
+			expect(body.data.refusedToday).toBeNull();
+			expect((vi.mocked(env.REFUSALS) as any).getByName).not.toHaveBeenCalled();
+		});
+
+		it.each([
+			['a hostname with an embedded newline', 'hostname=a%0Aforged'],
+			['a hostname longer than a DNS name may be', `hostname=${'a'.repeat(250)}.example.com`],
+		])('rejects %s the way /update does', async (_label, query) => {
+			// Unchecked, a typo answers with an empty page, which reads as
+			// "nothing ever happened to that name" rather than "you asked wrong".
+			const request = createMockRequest(`https://example.com/history?${query}`, { headers: validAuth });
+
+			const response = await worker.fetch(request, env, ctx);
+			const body = (await response.json()) as any;
+
+			expect(response.status).toBe(422);
+			expect(body.error).toContain('Not a valid hostname');
+		});
+
+		it('rejects a bad parameter without spending a Cloudflare API call', async () => {
+			// A request no token could answer should cost nothing beyond the
+			// worker invocation, which is the same bargain the access key strikes.
+			const request = createMockRequest('https://example.com/history?before=garbage', { headers: validAuth });
+
+			await worker.fetch(request, env, ctx);
+
+			expect(mockCloudflareClient.user.tokens.verify).not.toHaveBeenCalled();
+		});
+
+		it('rejects a cursor it did not emit rather than restarting the walk', async () => {
+			// Ignoring it would answer with the first page, and a client walking
+			// pages would read that as a fresh start and loop over the same rows.
+			const request = createMockRequest('https://example.com/history?before=garbage', { headers: validAuth });
+
+			const response = await worker.fetch(request, env, ctx);
+			const body = (await response.json()) as any;
+
+			expect(response.status).toBe(422);
+			expect(body.error).toContain("'before' parameter must be a cursor");
+		});
+
+		it('reports at most fifty refused names however many the counter holds', async () => {
+			// The counter keeps up to 200 of up to 253 characters, which would put
+			// 50 KiB of them on a response whose point is the audit rows.
+			const stub = (vi.mocked(env.REFUSALS) as any).getByName('token-id-123');
+			stub.tally.mockResolvedValue({
+				total: 400,
+				distinct: 200,
+				hostnames: Array.from({ length: 200 }, (_unused, i) => `h${String(i)}.example.com`),
+			});
+
+			const request = createMockRequest('https://example.com/history', { headers: validAuth });
+			const body = (await (await worker.fetch(request, env, ctx)).json()) as any;
+
+			expect(body.data.refusedToday.hostnames).toHaveLength(50);
+			// The true count still reaches the caller, so a truncated list never
+			// reads as the whole story.
+			expect(body.data.refusedToday.distinct).toBe(200);
+		});
+
 		it('returns 200 with events array using default limit of 100', async () => {
 			const auditDbMock = vi.mocked(env.AUDIT_DB) as any;
 			const stmtMock = auditDbMock.prepare();
@@ -3374,7 +3457,7 @@ describe('Worker fetch handler', () => {
 				data: { events: [{ hostname: 'test.example.com', outcome: 'updated' }] },
 			});
 			// token_id bound first, then limit (100) — no hostname in the middle
-			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 100);
+			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 101);
 		});
 
 		it('respects an explicit limit parameter', async () => {
@@ -3388,7 +3471,7 @@ describe('Worker fetch handler', () => {
 
 			await worker.fetch(request, env, ctx);
 
-			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 25);
+			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 26);
 		});
 
 		it('clamps limit to 1000 when the provided value exceeds the maximum', async () => {
@@ -3402,7 +3485,7 @@ describe('Worker fetch handler', () => {
 
 			await worker.fetch(request, env, ctx);
 
-			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 1000);
+			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 1001);
 		});
 
 		it('clamps limit to 1 when the provided value is less than 1', async () => {
@@ -3416,7 +3499,7 @@ describe('Worker fetch handler', () => {
 
 			await worker.fetch(request, env, ctx);
 
-			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 1);
+			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 2);
 		});
 
 		it('falls back to default limit when limit param is non-numeric', async () => {
@@ -3430,7 +3513,7 @@ describe('Worker fetch handler', () => {
 
 			await worker.fetch(request, env, ctx);
 
-			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 100);
+			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 101);
 		});
 
 		it('filters by hostname when the hostname query param is provided', async () => {
@@ -3445,7 +3528,7 @@ describe('Worker fetch handler', () => {
 			await worker.fetch(request, env, ctx);
 
 			// When hostname is set: token_id, hostname, limit are all bound in that order
-			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 'test.example.com', 100);
+			expect(stmtMock.bind).toHaveBeenCalledWith('token-id-123', 'test.example.com', 101);
 		});
 
 		it('returns 405 for non-GET requests to /history', async () => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,8 +1,17 @@
-import { cloudflareTest } from '@cloudflare/vitest-pool-workers';
+import { cloudflareTest, readD1Migrations } from '@cloudflare/vitest-pool-workers';
 import { defineConfig } from 'vitest/config';
 
+// The real migrations, handed to the test worker so a suite can build the
+// schema the deployment actually runs rather than a copy of it that drifts.
+const migrations = await readD1Migrations('./migrations');
+
 export default defineConfig({
-	plugins: [cloudflareTest({ wrangler: { configPath: './wrangler.jsonc' } })],
+	plugins: [
+		cloudflareTest({
+			wrangler: { configPath: './wrangler.jsonc' },
+			miniflare: { bindings: { TEST_MIGRATIONS: migrations } },
+		}),
+	],
 	test: {
 		// The first Durable Object call in a run pays for the namespace starting
 		// up, which can outlast the 5s default on a cold or loaded machine.


### PR DESCRIPTION
`GET /history` clamped at 1000 events with no way to ask for the next page, so a caller with more history than that simply could not reach it.

## Paging

Each page carries `data.cursor`, passed back as `before=`, resuming at the row the page ended on. It is `null` on the last page.

Keyed on `(occurred_at, id)` rather than the timestamp alone: a batch writes one row per record in the same millisecond, so a page boundary lands inside a group sharing a timestamp as a matter of course, and a timestamp-only cursor would either repeat that group or drop the rest of it.

The group orders by **ascending** id while timestamps descend. Audit rows ride `ctx.waitUntil`, so one can reach D1 well after the timestamp it carries; taking the highest id last means a row landing in a group the walk is still crossing gets picked up rather than sorted behind a cursor that already passed it.

The two predicates keep the leading index column a plain range, which is what makes a deep page cost the page and not the history behind it:

| Form | Deep page, 100k rows | Plan |
|---|---|---|
| `occurred_at <= ? AND (occurred_at < ? OR id > ?)` | **0.063 ms** | `token_id=? AND occurred_at<?` |
| `(occurred_at < ? OR (occurred_at = ? AND id > ?))` | 5.886 ms | `token_id=?` only |

## The cursor carries a row id, and that is a disclosed tradeoff

The id is a table-wide sequence, so on a deployment several people share, one caller can read the others' aggregate write volume and time their activity by polling. Never row contents, and nil on a single-household deployment.

Signing the cursor would close it and needs a deployment secret this worker does not require: `ACCESS_KEY` is optional, and the deployments that leave it unset are exactly the shared ones where it matters. Every id-free ordering I built and measured traded the leak for a walk that repeats or silently skips rows, which is the worse failure for an audit trail. The README states the caveat.

## Also in this change

- The refusal tally reports at most 50 names instead of up to 200 of up to 253 characters, which put 50 KiB on a response whose point is the audit rows. It reports the last to be seen for the first time, matching the alert's sample.
- The tally rides the first page only. Walking ten pages spent ten Durable Object round trips repeating it.
- `/history` holds `hostname` to the shape `/update` enforces, and checks every parameter **before** verifying the token, so a request no token could answer costs nothing beyond the worker invocation.
- The limit clamp rejects a non-finite value itself rather than relying on its one caller: `Math.trunc(NaN)` is `NaN`, every comparison against it is false, and SQLite rejects `NaN` bound to `LIMIT`.
- A cursor is matched against the shape the writer produces rather than coerced. `Number()` alone accepts `0x10`, `1e3`, and a leading newline; the timestamp pattern alone accepts `2026-99-99`, which sorts above every real row and would hand back the first page as a fresh start.
- `queryHistory` reads its own cursor back before returning it, so a row whose timestamp this module did not write degrades the walk to one page instead of a 422 blaming the caller for a value the server handed it.

## Verification

319 tests across 5 files, 100% statement/branch/function/line coverage, typecheck, lint and format clean, deploy dry-run builds.

`tests/history-walk.test.ts` is new and runs the walk against a **real local D1 built from the real migration**. The rest of the audit suite mocks D1, which can only assert the shape of the SQL that goes out; the contract this change exists to deliver is that a walk crossing a tie group returns every row exactly once, and no mock can answer that. It covers a 25-row group walked at page sizes 1, 2, 7 and 26, cross-tenant isolation, a late `waitUntil` write landing mid-walk, a hostname-filtered walk, and the off-by-one that would emit an empty final page.

Four rounds of adversarial review ran against this diff. The last found zero critical and zero high; the one medium is the disclosed cursor tradeoff above.
