### PR TITLE
chore(release)!: version 1.0.0 and deploy from release tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,13 @@ name: Deploy
 permissions:
   contents: read
 
+# Releases deploy, pushes do not. The deploy applies D1 migrations, so tying
+# it to a tag is what makes the schema in production correspond to a revision
+# anyone can check out, rather than to whichever commit last reached main.
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
 
 jobs:
@@ -23,6 +26,11 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      # A tag has no pull request behind it, so nothing else would have run
+      # these against the exact revision about to reach production.
+      - name: Verify
+        run: bun run check:all
 
       # scripts/deploy.ts is the single deploy path: it generates
       # wrangler.deploy.jsonc with the resource IDs, applies D1 migrations,

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Requires [bun](https://bun.sh).
    ```
 5. Note the `*.workers.dev` route.
 
-#### **Option 3: Deploy on every push with GitHub Actions**
+#### **Option 3: Deploy on every release with GitHub Actions**
 
 Fork this repository, run setup locally once (Option 2, steps 1 to 3), then add
-these repository secrets; every push to `main` deploys automatically:
+these repository secrets:
 
 - `CLOUDFLARE_API_TOKEN` - API token with Workers Scripts, Workers KV, and D1 edit permissions
 - `CLOUDFLARE_ACCOUNT_ID` - Your Cloudflare account ID
@@ -69,6 +69,18 @@ these repository secrets; every push to `main` deploys automatically:
 - `KV_NAMESPACE_PREVIEW_ID` - Preview namespace ID (from `.env.local`)
 - `D1_DATABASE_ID` - Audit database ID (from `.env.local`)
 - `ACCESS_KEY` - Optional; locks the worker to callers that present it
+
+Pushing a `v*.*.*` tag then verifies and deploys that revision:
+
+```sh
+git tag v1.0.1
+git push origin v1.0.1
+```
+
+Tags rather than every push to `main`, because the deploy applies the D1
+migrations. Tying it to a tag means the schema in production corresponds to a
+revision you can check out, instead of to whichever commit landed last. Use the
+workflow's manual run to deploy without cutting a tag.
 
 Notifications need no deployment configuration: callers pass their own ntfy
 target with the `ntfy=` query parameter.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "uddns",
-	"version": "3.1.1",
+	"version": "1.0.0",
 	"private": true,
 	"type": "module",
 	"packageManager": "bun@1.3.13",


### PR DESCRIPTION
The 3.x numbering came from `willswire/unifi-ddns` through the fork and never described anything this repository released: no tags, no GitHub releases, and the package is private and unpublished, so nothing depends on it. CLAUDE.md already calls this an independent project; the version now says so too.

## Deploys move to tags

`v*.*.*` tags deploy. Pushing to `main` no longer does, and `workflow_dispatch` stays as the way to deploy without cutting a tag.

The deploy applies the D1 migrations, so tying it to a tag makes the schema in production correspond to a revision anyone can check out, rather than to whichever commit landed last.

## The deploy now verifies first

A tag has no pull request behind it, so nothing would have run the checks against the exact revision reaching production. On a push to `main`, `ci.yml` and `deploy.yml` fired independently and raced each other, so a broken commit deployed in parallel with the tests that would have caught it. The deploy job now runs `check:all` before `bun run deploy`.

Net effect on blast radius is a tightening: pushing a tag and pushing to `main` both need push access, and the deploy is now gated on checks that previously nothing enforced.

## Sequencing

This lands after #185 and #186, deliberately. Both are already deployed to production from the old push trigger, so **this PR changes no worker code and production is already running the code a `v1.0.0` tag will deploy**. If the tag-triggered workflow is wrong on first use, production is unaffected and `workflow_dispatch` is the escape hatch. Folding this into an earlier PR would have forfeited that.

## Verification

319 tests, 100% coverage, typecheck, lint and format clean. No worker code changed.
