### PR TITLE
fix(refusals): bound the counted day window against the clock

### DIFF
--- a/src/refusals.ts
+++ b/src/refusals.ts
@@ -42,8 +42,10 @@ export interface RefusalUpdate extends RefusalTally {
 
 const STATE_KEY = 'count';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 /** How long past a tally's own day an instance keeps it before clearing. */
-const RECLAIM_AFTER_DAY_MS = 48 * 60 * 60 * 1000;
+const RECLAIM_AFTER_DAY_MS = 2 * DAY_MS;
 
 /**
  * Distinct names kept per day. The names come from the caller, so this set is
@@ -89,21 +91,34 @@ export const ALERT_DISTINCT = 100;
 
 const DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
-/** Furthest alarm the platform accepts, which rules out a far-future day. */
-const ALARM_LATEST_MS = Date.parse('2189-01-01T00:00:00.000Z');
-
 /**
- * The day is stamped by the caller and reaches both a lexicographic comparison
- * and the alarm anchor, so one this does not admit would either compare wrong
- * or make `setAlarm` throw: on NaN from an unparseable date, and on a date past
- * the ceiling the platform will schedule against.
+ * Whether a day is one this object will count, measured against the clock the
+ * caller stamps from.
+ *
+ * A day is a lexicographic comparison and an alarm anchor, and each end of the
+ * window answers one of them. Behind the window, the alarm arms behind the
+ * clock, so the tally written under that day is cleared on the way out. Ahead
+ * of it, the stored day sits above every later call, each of which then reads
+ * as a straggler: one such write takes the tally dark for the life of the
+ * instance. The far end also keeps the alarm inside the ceiling the platform
+ * will schedule against.
+ *
+ * The near end reaches back a full reclaim period rather than a day, because a
+ * request that stamps its day just before midnight can land just after, and
+ * that straggler has to arrive as one. The one caller stamps the current day,
+ * whose ends sit a day clear of the window either way, so this is a backstop
+ * rather than a line production approaches.
  */
 function isDay(value: string): boolean {
 	if (!DAY_PATTERN.test(value)) {
 		return false;
 	}
 	const anchor = Date.parse(`${value}T00:00:00.000Z`);
-	return !Number.isNaN(anchor) && anchor + RECLAIM_AFTER_DAY_MS < ALARM_LATEST_MS;
+	if (Number.isNaN(anchor)) {
+		return false;
+	}
+	const now = Date.now();
+	return anchor + RECLAIM_AFTER_DAY_MS > now && anchor < now + DAY_MS;
 }
 
 /** Stored state is read back as unknown: a shape that does not match is absent. */
@@ -162,7 +177,17 @@ export class RefusalCounter extends DurableObject<Env> {
 		const names = hostnames
 			.slice(0, DISTINCT_NAMES_MAX)
 			.filter((name) => typeof name === 'string' && name !== '' && name.length <= NAME_MAX_LENGTH);
-		if (!isDay(day) || names.length === 0) {
+		if (!isDay(day)) {
+			// The caller stamps the current day, so reaching here says its clock
+			// disagrees with this object's. Worth a line precisely because it
+			// should not happen: the tally answers only through `/history`,
+			// scoped to the token being counted, so a counter that stops
+			// counting looks exactly like a quiet one. The day is escaped and
+			// cut, since the value reaching here matched nothing.
+			console.warn('refusals: ignoring a day outside the counted window', JSON.stringify(day).slice(0, 40));
+			return EMPTY;
+		}
+		if (names.length === 0) {
 			return EMPTY;
 		}
 		const stored = await this.ctx.storage.get(STATE_KEY);

--- a/tests/refusals.test.ts
+++ b/tests/refusals.test.ts
@@ -2,14 +2,27 @@ import { env } from 'cloudflare:workers';
 import { runDurableObjectAlarm } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * A day that many days from the current UTC one, the way the worker stamps it.
+ *
+ * The object holds a tally only while that day's reclaim deadline is still
+ * ahead of the clock, so a day fixed in the source stops being one the object
+ * accepts as soon as the clock passes it.
+ */
+const dayAt = (offset: number): string => new Date(Date.now() + offset * DAY_MS).toISOString().slice(0, 10);
+
+const yesterday = dayAt(-1);
+const today = dayAt(0);
+const tomorrow = dayAt(1);
+
 /**
  * Exercised against a real Durable Object rather than a stub: the reason this
  * counter is a DO at all is that instance requests serialize, and a stub would
  * assert that property rather than test it.
  */
 describe('RefusalCounter', () => {
-	const today = '2026-08-06';
-
 	it('reports nothing for a token it has never seen', async () => {
 		await expect(env.REFUSALS.getByName('fresh-token').tally(today)).resolves.toEqual({ total: 0, distinct: 0, hostnames: [] });
 	});
@@ -70,11 +83,15 @@ describe('RefusalCounter', () => {
 
 	it('starts over when the day rolls', async () => {
 		const counter = env.REFUSALS.getByName('rolling-token');
-		await counter.add('2026-08-05', ['old.example.com', 'older.example.com']);
+		await counter.add(yesterday, ['old.example.com', 'older.example.com']);
+		// The roll is only under test if there is a tally to roll off. The day
+		// window is measured against the clock, so a yesterday the object turns
+		// away would leave the assertion below true for the wrong reason.
+		await expect(counter.tally(yesterday)).resolves.toMatchObject({ total: 2 });
 
-		await counter.add('2026-08-06', ['new.example.com']);
+		await counter.add(today, ['new.example.com']);
 
-		await expect(counter.tally('2026-08-06')).resolves.toEqual({
+		await expect(counter.tally(today)).resolves.toEqual({
 			total: 1,
 			distinct: 1,
 			hostnames: ['new.example.com'],
@@ -83,9 +100,10 @@ describe('RefusalCounter', () => {
 
 	it('reports nothing for a day it holds no tally for', async () => {
 		const counter = env.REFUSALS.getByName('stale-token');
-		await counter.add('2026-08-05', ['old.example.com']);
+		await counter.add(yesterday, ['old.example.com']);
+		await expect(counter.tally(yesterday)).resolves.toMatchObject({ total: 1 });
 
-		await expect(counter.tally('2026-08-06')).resolves.toEqual({ total: 0, distinct: 0, hostnames: [] });
+		await expect(counter.tally(today)).resolves.toEqual({ total: 0, distinct: 0, hostnames: [] });
 	});
 
 	it('stops collecting names at the cap while the total keeps climbing', async () => {
@@ -120,8 +138,6 @@ describe('RefusalCounter', () => {
 });
 
 describe('RefusalCounter guards', () => {
-	const today = '2026-08-06';
-
 	it.each([
 		['an empty list', []],
 		['entries that are not names', ['', '']],
@@ -201,13 +217,17 @@ describe('RefusalCounter guards', () => {
 		['a day that is not a date', 'yesterday'],
 		['a day out of range', '2026-13-45'],
 		['a timestamp rather than a day', '2026-08-06T12:00:00Z'],
-		// The alarm anchor is the day plus the reclaim window, and the platform
-		// refuses to schedule past 2189. The pattern alone would admit this.
-		['a day past the furthest alarm', '9999-12-31'],
+		// The pattern alone would admit these. A day the object stores ahead of
+		// the clock sits above every later call, so each reads as a straggler
+		// and the tally goes dark for the life of the instance. The nearer one
+		// is the one worth pinning: it is a plausible date, and an alarm can be
+		// scheduled against it.
+		['a day ahead of the window', '2100-01-01'],
+		['a day far ahead of the window', '9999-12-31'],
 	])('ignores %s rather than poisoning the tally', async (_label, day) => {
 		// The day reaches both a lexicographic comparison and the alarm anchor,
-		// where a value this does not admit would compare wrong or make setAlarm
-		// throw.
+		// where a value this does not admit would compare wrong, make setAlarm
+		// throw, or delete what it stores.
 		const counter = env.REFUSALS.getByName(`day-guard-${day}`);
 		await counter.add(today, ['real.example.com']);
 
@@ -216,18 +236,43 @@ describe('RefusalCounter guards', () => {
 		await expect(counter.tally(today)).resolves.toMatchObject({ total: 1, distinct: 1 });
 	});
 
+	it('refuses a day whose reclaim window already passed', async () => {
+		// The other end of the alarm anchor, and it needs an instance holding no
+		// tally: with one, the straggler check answers first and the day never
+		// reaches setAlarm. On a fresh instance nothing else stands between the
+		// two, so admitting the day would arm the alarm behind the clock and
+		// clear the tally the same call wrote.
+		const counter = env.REFUSALS.getByName('expired-day-token');
+		const expired = dayAt(-3);
+
+		await expect(counter.add(expired, ['stale.example.com'])).resolves.toEqual({
+			total: 0,
+			distinct: 0,
+			hostnames: [],
+			alert: false,
+		});
+
+		await expect(counter.tally(expired)).resolves.toEqual({ total: 0, distinct: 0, hostnames: [] });
+	});
+
 	it('ignores a call stamped with an older day', async () => {
 		// The caller stamps the day and its RPC can land out of order, so a
 		// straggler from yesterday must not reset today.
 		const counter = env.REFUSALS.getByName('straggler-token');
-		await counter.add('2026-08-06', ['today.example.com']);
+		await counter.add(today, ['today.example.com']);
 
-		await counter.add('2026-08-05', ['yesterday.example.com']);
+		await counter.add(yesterday, ['yesterday.example.com']);
 
-		await expect(counter.tally('2026-08-06')).resolves.toEqual({
+		await expect(counter.tally(today)).resolves.toEqual({
 			total: 1,
 			distinct: 1,
 			hostnames: ['today.example.com'],
+		});
+		// Which of the two refusals answered matters, and both return the same
+		// empty tally. The control pins it on the straggler check: the same day
+		// counts normally against an instance holding nothing above it.
+		await expect(env.REFUSALS.getByName('straggler-control').add(yesterday, ['yesterday.example.com'])).resolves.toMatchObject({
+			total: 1,
 		});
 	});
 
@@ -245,9 +290,9 @@ describe('RefusalCounter guards', () => {
 	it('raises the alert again once the day rolls', async () => {
 		// The flag is part of the day's tally, so a new day starts silent.
 		const counter = env.REFUSALS.getByName('alert-rolling-token');
-		await counter.add('2026-08-06', names(100, 'a'));
+		await counter.add(today, names(100, 'a'));
 
-		await expect(counter.add('2026-08-07', names(100, 'a'))).resolves.toMatchObject({ alert: true });
+		await expect(counter.add(tomorrow, names(100, 'a'))).resolves.toMatchObject({ alert: true });
 	});
 
 	it('raises the alert on the next call when one is lost after the write', async () => {


### PR DESCRIPTION
## Why

`main` is red, and has been since **2026-08-08**. Nothing on `main` changed that day; the wall clock passed a date baked into the tests.

The `RefusalCounter` anchors its reclaim alarm at the tally's day plus the 48h reclaim window. `tests/refusals.test.ts` stamped a fixed `2026-08-06`, so from `2026-08-08` that anchor sat in the past. `setAlarm` fires immediately on a past time, `alarm()` runs `deleteAll()`, and the tally is gone before the next assertion reads it. Seventeen cases went down together.

Confirmed unrelated to #188: `main` at `2b37441` with the pre-bump lockfile fails identically.

## What this fixes

`isDay` had a ceiling and no floor. Both ends now measure against the clock the caller stamps from.

| Day | Before | After |
| --- | --- | --- |
| Today | counted | counted |
| Yesterday | counted | counted |
| Two days back or older | **stored, then wiped by its own alarm** | refused |
| Anywhere before 2189 | **stored, and pins the tally dark** | refused |
| 2189 or later | refused | refused |

The far end was the worse of the two, and the red-team pass found it rather than CI. A day like `2100-01-01` cleared the old ceiling, so the object stored it. Every later call then compared `2100-01-01 > today`, took the straggler branch, and returned an empty tally. `WRITES_MAX` never engaged, so nothing reclaimed it either: one accepted stamp took that token's refusal signal dark for the life of the instance. Not reachable over the network, since `day` only ever comes from `currentDay()`, but the class is written as a standalone contract and the tests say so in as many words.

The new far end reaches forward one day, which subsumes the 2189 ceiling, so `ALARM_LATEST_MS` is gone. The near end reaches back a full reclaim period rather than a day, so a request that stamps its day just before midnight and lands just after still arrives as a straggler.

A rejected day now warns. It should be unreachable, and the tally is readable only through `/history` scoped to the token being counted, so a counter that stops counting otherwise looks exactly like a quiet one.

## Tests

Days derive from the current UTC date, the way the worker stamps them.

The three cases that turn on an older day now assert that the older day landed. Without that, a `yesterday` the object turns away leaves all three passing while testing nothing, and the straggler branch is the one that stops an out-of-order RPC from resetting a live tally. The straggler case also adds a control on a second instance, because a day-window refusal and a straggler refusal return the same empty tally and only one of them is the point.

321 tests, 100% statements/branches/functions/lines.

## Known limit, deliberately not fixed

The near bound is an edge, not a margin: a day one millisecond inside it arms the alarm one millisecond out, and `add` returns a tally that `deleteAll` then clears. Every margin wide enough to close this also rejects `yesterday`, which would make the straggler branch dead code. The only caller stamps the current day, whose margin is at least 24 hours.