### PR TITLE
chore: own every path in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# The main ruleset requires a code owner review. Without this file no path has
+# an owner, so that requirement passes on every pull request and protects
+# nothing. One owner over everything is the honest description of the repository
+# today, and it auto-requests a review on anything a contributor opens.
+
+* @zachthedev


### PR DESCRIPTION
The `main` ruleset sets `require_code_owner_review: true`, and no CODEOWNERS file exists. With no file, no changed path has an owner, so the requirement is satisfied vacuously by every pull request.

Proven rather than reasoned: #193 merged on a single approval from a non-owner, no `--admin`, with the flag active.

## What changes

`* @zachthedev`. The flag starts meaning something, and any pull request a contributor opens auto-requests your review.

## What does not change

Pull requests you author. When the sole code owner is also the author, [the requirement cannot be satisfied](https://github.com/orgs/community/discussions/9636) and the merge needs the admin bypass. Yours already do, for want of a second reviewer, so this adds no friction that was not there.

Release pull requests keep working normally: `github-actions[bot]` is the author, you are a code owner, and your approval satisfies both the count and the ownership clause. It also means release PRs now land in your review queue on their own.

This pull request is not itself subject to the rule; GitHub reads CODEOWNERS from the base branch, and `main` has none yet.